### PR TITLE
Added configuration for Travis-CI, CodeCov and Stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,6 @@
+---
+linters:
+    golint:
+        min_confidence: 0.85
+fixers:
+    enable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+
+sudo: false
+
+go:
+  - "1.8"
+  - "1.9"
+  - "1.10"
+  - tip
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - ./.travis/tests.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# because things are never simple.
+# See https://github.com/codecov/example-go#caveat-multiple-files
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
Adding three external apps:
* Travis-CI, for test automation
* Stickler, for code linting (it will comment on the PR but it's not push-blocking)
* CodeCov, to measure test coverage and complain if it decreases