### PR TITLE
Replace Parse functions with JSON marshalling

### DIFF
--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -142,8 +142,8 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	flash.Master = *master
 
 	// BIOS region
-	biosBase := uint32(uint32(flash.Region.BiosBase) * 0x1000)
-	biosSize := uint32(computeRegionSize(flash.Region.BiosBase, flash.Region.BiosLimit))
+	biosBase := uint32(flash.Region.BIOS.Base) * 0x1000
+	biosSize := computeRegionSize(flash.Region.BIOS.Base, flash.Region.BIOS.Limit)
 	br, err := NewBiosRegion(buf[biosBase : biosBase+biosSize])
 	if err != nil {
 		return nil, err

--- a/uefi/flashmastersection.go
+++ b/uefi/flashmastersection.go
@@ -9,23 +9,29 @@ import (
 // FlashMasterSectionSize is the size in bytes of the FlashMaster section
 const FlashMasterSectionSize = 12
 
+// RegionPermissions holds the read/write permissions for other regions.
+type RegionPermissions struct {
+	ID    uint16
+	Read  uint8
+	Write uint8
+}
+
+func (r RegionPermissions) String() string {
+	return fmt.Sprintf("RegionPermissions{ID=%v, Read=0x%x, Write=0x%x}",
+		r.ID, r.Read, r.Write)
+}
+
 // FlashMasterSection holds all the IDs and read/write permissions for other regions
 // This controls whether the bios region can read/write to the ME for example.
 type FlashMasterSection struct {
-	BiosID    uint16
-	BiosRead  uint8
-	BiosWrite uint8
-	MeID      uint16
-	MeRead    uint8
-	MeWrite   uint8
-	GbeID     uint16
-	GbeRead   uint8
-	GbeWrite  uint8
+	BIOS RegionPermissions
+	ME   RegionPermissions
+	GBE  RegionPermissions
 }
 
 func (m FlashMasterSection) String() string {
-	return fmt.Sprintf("FlashMasterSection{BiosID=%v, MeID=%v, GbeID=%v}",
-		m.BiosID, m.MeID, m.GbeID)
+	return fmt.Sprintf("FlashMasterSection{Bios %v, Me %v, Gbe %v}",
+		m.BIOS, m.ME, m.GBE)
 }
 
 // Summary prints a multi-line description of the FlashMasterSection
@@ -41,9 +47,9 @@ func (m FlashMasterSection) Summary() string {
 		"    GbeRead=%v\n"+
 		"    GbeWrite=%v\n"+
 		"}",
-		m.BiosID, m.BiosRead, m.BiosWrite,
-		m.MeID, m.MeRead, m.MeWrite,
-		m.GbeID, m.GbeRead, m.GbeWrite,
+		m.BIOS.ID, m.BIOS.Read, m.BIOS.Write,
+		m.ME.ID, m.ME.Read, m.ME.Write,
+		m.GBE.ID, m.GBE.Read, m.GBE.Write,
 	)
 }
 

--- a/uefi/flashparams.go
+++ b/uefi/flashparams.go
@@ -31,7 +31,7 @@ var FlashFrequencyStringMap = map[FlashFrequency]string{
 }
 
 // FlashParams is a 4-byte object that holds the flash parameters information.
-type FlashParams []byte
+type FlashParams [4]byte
 
 // FirstChipDensity returns the size of the first chip.
 func (p FlashParams) FirstChipDensity() uint {
@@ -122,6 +122,7 @@ func NewFlashParams(buf []byte) (*FlashParams, error) {
 			len(buf),
 		)
 	}
-	p := FlashParams(buf)
+	var p FlashParams
+	copy(p[:], buf[0:FlashParamsSize])
 	return &p, nil
 }

--- a/utk/utk.go
+++ b/utk/utk.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"encoding/json"
 
 	"github.com/linuxboot/fiano/uefi"
 )
@@ -31,5 +32,9 @@ func main() {
 	if len(errlist) > 0 {
 		os.Exit(1)
 	}
-	fmt.Println(flash.Summary())
+	b, err:= json.MarshalIndent(flash, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(b))
 }


### PR DESCRIPTION
This allows us to prepare to serialize out metadata into files for easy parsing, and we can remove the Summary calls as I've made the Json print out similar fields to the Summary calls