### PR TITLE
Reorg flash

### DIFF
--- a/uefi/biosregion.go
+++ b/uefi/biosregion.go
@@ -5,41 +5,49 @@ import (
 	"strings"
 )
 
-// BiosRegion represents the Bios Region in the firmware.
+// BIOSRegion represents the Bios Region in the firmware.
 // It holds all the FVs as well as padding
 // TODO(ganshun): handle padding
-type BiosRegion struct {
+type BIOSRegion struct {
+	// holds the raw data
+	buf             []byte
 	FirmwareVolumes []FirmwareVolume
+
+	//Metadata for extraction and recovery
+	ExtractPath string
+	// This is a pointer to the Region struct laid out in the ifd
+	Position *Region
 }
 
 // Summary prints a multi-line description of the Bios Region
-func (br BiosRegion) Summary() string {
+func (br BIOSRegion) Summary() string {
 	var fvols []string
 	for _, fv := range br.FirmwareVolumes {
 		fvols = append(fvols, fv.Summary())
 	}
-	return fmt.Sprintf("BiosRegion{\n"+
+	return fmt.Sprintf("BIOSRegion{\n"+
 		"    FirmwareVolumes=[\n"+
 		"        %v\n"+
 		"    ]\n"+
 		"}", Indent(strings.Join(fvols, "\n"), 8))
 }
 
-// NewBiosRegion parses a sequence of bytes and returns a BiosRegion
-// object, if a valid one is passed, or an error
-func NewBiosRegion(data []byte) (*BiosRegion, error) {
-	var br BiosRegion
+// NewBIOSRegion parses a sequence of bytes and returns a BIOSRegion
+// object, if a valid one is passed, or an error. It also points to the
+// Region struct uncovered in the ifd.
+func NewBIOSRegion(buf []byte, r *Region) (*BIOSRegion, error) {
+	br := BIOSRegion{buf: buf, Position: r}
 	for {
-		offset := FindFirmwareVolumeOffset(data)
+		offset := FindFirmwareVolumeOffset(buf)
 		if offset == -1 {
 			// no firmware volume found, stop searching
 			break
 		}
-		fv, err := NewFirmwareVolume(data[offset:])
+		fv, err := NewFirmwareVolume(buf[offset:])
 		if err != nil {
 			return nil, err
 		}
-		data = data[uint64(offset)+fv.Length:]
+		buf = buf[uint64(offset)+fv.Length:]
 		br.FirmwareVolumes = append(br.FirmwareVolumes, *fv)
 		// FIXME remove the `break` and move the offset to the next location to
 		// search for FVs (i.e. offset + fv.size)

--- a/uefi/firmwarevolume.go
+++ b/uefi/firmwarevolume.go
@@ -104,7 +104,6 @@ func FindFirmwareVolumeOffset(data []byte) int64 {
 // object, if a valid one is passed, or an error
 func NewFirmwareVolume(data []byte) (*FirmwareVolume, error) {
 	var fv FirmwareVolume
-	var ok bool
 
 	if len(data) < FirmwareVolumeMinSize {
 		return nil, fmt.Errorf("Firmware Volume size too small: expected %v bytes, got %v",
@@ -132,6 +131,7 @@ func NewFirmwareVolume(data []byte) (*FirmwareVolume, error) {
 	fv.Blocks = blocks
 
 	if guid, err := uuid.FromBytes(fv.FileSystemGUID[:]); err == nil {
+		var ok bool
 		fv.guidString = guid.String()
 		fv.guidName, ok = FirmwareVolumeGUIDs[fv.guidString]
 		if !ok {

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -40,6 +40,9 @@ type FlashImage struct {
 	IFD FlashDescriptor
 	// Actual regions
 	BIOSRegion *BIOSRegion
+	MERegion   *MERegion
+	GBERegion  *GBERegion
+	PDRRegion  *PDRRegion
 
 	// Metadata for extraction and recovery
 	ExtractPath string
@@ -155,11 +158,41 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	f.IFD.Master = *master
 
 	// BIOS region
+	if !f.IFD.Region.BIOS.Available() {
+		return nil, fmt.Errorf("no BIOS region: invalid region parameters %v", f.IFD.Region.BIOS)
+	}
 	br, err := NewBIOSRegion(buf[f.IFD.Region.BIOS.BaseOffset():f.IFD.Region.BIOS.EndOffset()], &f.IFD.Region.BIOS)
 	if err != nil {
 		return nil, err
 	}
 	f.BIOSRegion = br
+
+	// ME region
+	if f.IFD.Region.ME.Available() {
+		mer, err := NewMERegion(buf[f.IFD.Region.ME.BaseOffset():f.IFD.Region.ME.EndOffset()], &f.IFD.Region.ME)
+		if err != nil {
+			return nil, err
+		}
+		f.MERegion = mer
+	}
+
+	// GBE region
+	if f.IFD.Region.GBE.Available() {
+		gber, err := NewGBERegion(buf[f.IFD.Region.GBE.BaseOffset():f.IFD.Region.GBE.EndOffset()], &f.IFD.Region.GBE)
+		if err != nil {
+			return nil, err
+		}
+		f.GBERegion = gber
+	}
+
+	// PDR region
+	if f.IFD.Region.PDR.Available() {
+		pdrr, err := NewPDRRegion(buf[f.IFD.Region.PDR.BaseOffset():f.IFD.Region.PDR.EndOffset()], &f.IFD.Region.PDR)
+		if err != nil {
+			return nil, err
+		}
+		f.PDRRegion = pdrr
+	}
 
 	return &f, nil
 }

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -158,7 +158,7 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	f.IFD.Master = *master
 
 	// BIOS region
-	if !f.IFD.Region.BIOS.Available() {
+	if !f.IFD.Region.BIOS.Valid() {
 		return nil, fmt.Errorf("no BIOS region: invalid region parameters %v", f.IFD.Region.BIOS)
 	}
 	br, err := NewBIOSRegion(buf[f.IFD.Region.BIOS.BaseOffset():f.IFD.Region.BIOS.EndOffset()], &f.IFD.Region.BIOS)
@@ -168,7 +168,7 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	f.BIOSRegion = br
 
 	// ME region
-	if f.IFD.Region.ME.Available() {
+	if f.IFD.Region.ME.Valid() {
 		mer, err := NewMERegion(buf[f.IFD.Region.ME.BaseOffset():f.IFD.Region.ME.EndOffset()], &f.IFD.Region.ME)
 		if err != nil {
 			return nil, err
@@ -177,7 +177,7 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	}
 
 	// GBE region
-	if f.IFD.Region.GBE.Available() {
+	if f.IFD.Region.GBE.Valid() {
 		gber, err := NewGBERegion(buf[f.IFD.Region.GBE.BaseOffset():f.IFD.Region.GBE.EndOffset()], &f.IFD.Region.GBE)
 		if err != nil {
 			return nil, err
@@ -186,7 +186,7 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	}
 
 	// PDR region
-	if f.IFD.Region.PDR.Available() {
+	if f.IFD.Region.PDR.Valid() {
 		pdrr, err := NewPDRRegion(buf[f.IFD.Region.PDR.BaseOffset():f.IFD.Region.PDR.EndOffset()], &f.IFD.Region.PDR)
 		if err != nil {
 			return nil, err

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -39,7 +39,7 @@ type FlashImage struct {
 	// Holds the Flash Descriptor
 	IFD FlashDescriptor
 	// Actual regions
-	BiosRegion *BiosRegion
+	BIOSRegion *BIOSRegion
 
 	// Metadata for extraction and recovery
 	ExtractPath string
@@ -100,7 +100,7 @@ func (f FlashImage) Summary() string {
 		"    Descriptor=%v\n"+
 		"    Region=%v\n"+
 		"    Master=%v\n"+
-		"    BiosRegion=%v\n"+
+		"    BIOSRegion=%v\n"+
 		"}",
 		len(f.buf),
 		f.IFD.DescriptorMapStart,
@@ -109,15 +109,8 @@ func (f FlashImage) Summary() string {
 		Indent(f.IFD.DescriptorMap.Summary(), 4),
 		Indent(f.IFD.Region.Summary(), 4),
 		Indent(f.IFD.Master.Summary(), 4),
-		Indent(f.BiosRegion.Summary(), 4),
+		Indent(f.BIOSRegion.Summary(), 4),
 	)
-}
-
-func computeRegionSize(base, limit uint16) uint32 {
-	if limit == 0 {
-		return 0
-	}
-	return (uint32(limit) + 1 - uint32(base)) * 0x1000
 }
 
 // NewFlashImage tries to create a FlashImage structure, and returns a FlashImage
@@ -162,13 +155,11 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 	f.IFD.Master = *master
 
 	// BIOS region
-	biosBase := uint32(f.IFD.Region.BIOS.Base) * 0x1000
-	biosSize := computeRegionSize(f.IFD.Region.BIOS.Base, f.IFD.Region.BIOS.Limit)
-	br, err := NewBiosRegion(buf[biosBase : biosBase+biosSize])
+	br, err := NewBIOSRegion(buf[f.IFD.Region.BIOS.BaseOffset():f.IFD.Region.BIOS.EndOffset()], &f.IFD.Region.BIOS)
 	if err != nil {
 		return nil, err
 	}
-	f.BiosRegion = br
+	f.BIOSRegion = br
 
 	return &f, nil
 }

--- a/uefi/flashregionsection.go
+++ b/uefi/flashregionsection.go
@@ -10,23 +10,6 @@ import (
 // FlashRegionSectionSize is the size of the Region descriptor. It is made up by 18 fields, each 16-bits large.
 const FlashRegionSectionSize = 36
 
-// Region contains the start and end of a region in flash. This can be a BIOS, ME, PDR or GBE region.
-// This value seems to index blocks of block size 0x1000
-// TODO: figure out of block sizes are read from some location on flash or fixed.
-type Region struct {
-	Base  uint16
-	Limit uint16
-}
-
-// Available checks to see if a region is valid
-func (r *Region) Available() bool {
-	return r.Limit > 0
-}
-
-func (r *Region) String() string {
-	return fmt.Sprintf("[%#x, %#x)", r.Base, r.Limit)
-}
-
 // FlashRegionSection holds the metadata of all the different flash regions like PDR, Gbe and the Bios region.
 type FlashRegionSection struct {
 	_                   uint16

--- a/uefi/flashregionsection.go
+++ b/uefi/flashregionsection.go
@@ -24,7 +24,7 @@ func (r *Region) Available() bool {
 }
 
 func (r *Region) String() string {
-	return fmt.Sprintf("[0x%x, 0x%x)", r.Base, r.Limit)
+	return fmt.Sprintf("[%#x, %#x)", r.Base, r.Limit)
 }
 
 // FlashRegionSection holds the metadata of all the different flash regions like PDR, Gbe and the Bios region.

--- a/uefi/flashregionsection.go
+++ b/uefi/flashregionsection.go
@@ -20,19 +20,19 @@ type FlashRegionSection struct {
 	PDR                 Region
 }
 
-// AvailableRegions returns a list of names of the regions with non-zero size.
-func (f FlashRegionSection) AvailableRegions() []string {
+// ValidRegions returns a list of names of the regions with non-zero size.
+func (f FlashRegionSection) ValidRegions() []string {
 	var regions []string
-	if f.BIOS.Available() {
+	if f.BIOS.Valid() {
 		regions = append(regions, "BIOS")
 	}
-	if f.ME.Available() {
+	if f.ME.Valid() {
 		regions = append(regions, "ME")
 	}
-	if f.GBE.Available() {
+	if f.GBE.Valid() {
 		regions = append(regions, "GbE")
 	}
-	if f.PDR.Available() {
+	if f.PDR.Valid() {
 		regions = append(regions, "PDR")
 	}
 	return regions
@@ -40,7 +40,7 @@ func (f FlashRegionSection) AvailableRegions() []string {
 
 func (f FlashRegionSection) String() string {
 	return fmt.Sprintf("FlashRegionSection{Regions=%v}",
-		strings.Join(f.AvailableRegions(), ","),
+		strings.Join(f.ValidRegions(), ","),
 	)
 }
 
@@ -53,7 +53,7 @@ func (f FlashRegionSection) Summary() string {
 		"    Gbe=%v\n"+
 		"    Pdr=%v\n"+
 		"}",
-		strings.Join(f.AvailableRegions(), ","),
+		strings.Join(f.ValidRegions(), ","),
 		f.BIOS,
 		f.ME,
 		f.GBE,

--- a/uefi/gberegion.go
+++ b/uefi/gberegion.go
@@ -1,0 +1,19 @@
+package uefi
+
+// GBERegion represents the GBE Region in the firmware.
+type GBERegion struct {
+	// holds the raw data
+	buf []byte
+	//Metadata for extraction and recovery
+	ExtractPath string
+	// This is a pointer to the Region struct laid out in the ifd
+	Position *Region
+}
+
+// NewGBERegion parses a sequence of bytes and returns a GBERegion
+// object, if a valid one is passed, or an error. It also points to the
+// Region struct uncovered in the ifd.
+func NewGBERegion(buf []byte, r *Region) (*GBERegion, error) {
+	gbe := GBERegion{buf: buf, Position: r}
+	return &gbe, nil
+}

--- a/uefi/meregion.go
+++ b/uefi/meregion.go
@@ -1,0 +1,19 @@
+package uefi
+
+// MERegion represents the ME Region in the firmware.
+type MERegion struct {
+	// holds the raw data
+	buf []byte
+	//Metadata for extraction and recovery
+	ExtractPath string
+	// This is a pointer to the Region struct laid out in the ifd
+	Position *Region
+}
+
+// NewMERegion parses a sequence of bytes and returns a MERegion
+// object, if a valid one is passed, or an error. It also points to the
+// Region struct uncovered in the ifd.
+func NewMERegion(buf []byte, r *Region) (*MERegion, error) {
+	me := MERegion{buf: buf, Position: r}
+	return &me, nil
+}

--- a/uefi/pdrregion.go
+++ b/uefi/pdrregion.go
@@ -1,0 +1,19 @@
+package uefi
+
+// PDRRegion represents the PDR Region in the firmware.
+type PDRRegion struct {
+	// holds the raw data
+	buf []byte
+	//Metadata for extraction and recovery
+	ExtractPath string
+	// This is a pointer to the Region struct laid out in the ifd
+	Position *Region
+}
+
+// NewPDRRegion parses a sequence of bytes and returns a PDRRegion
+// object, if a valid one is passed, or an error. It also points to the
+// Region struct uncovered in the ifd.
+func NewPDRRegion(buf []byte, r *Region) (*PDRRegion, error) {
+	pdr := PDRRegion{buf: buf, Position: r}
+	return &pdr, nil
+}

--- a/uefi/region.go
+++ b/uefi/region.go
@@ -21,8 +21,8 @@ type Region struct {
 	Limit uint16
 }
 
-// Available checks to see if a region is valid
-func (r *Region) Available() bool {
+// Valid checks to see if a region is valid
+func (r *Region) Valid() bool {
 	return r.Limit > 0
 }
 

--- a/uefi/region.go
+++ b/uefi/region.go
@@ -1,0 +1,41 @@
+package uefi
+
+import (
+	"fmt"
+)
+
+// Region contains the start and end of a region in flash. This can be a BIOS, ME, PDR or GBE region.
+// This value seems to index blocks of block size 0x1000
+// TODO: figure out of block sizes are read from some location on flash or fixed.
+// Right now we assume they're fixed
+
+const (
+	// RegionBlockSize assumes the region struct values correspond to blocks of 0x1000 in size
+	RegionBlockSize = 0x1000
+)
+
+// Region holds the base and limit of every type of region. Each region such as the bios region
+// should point back to it.
+type Region struct {
+	Base  uint16
+	Limit uint16
+}
+
+// Available checks to see if a region is valid
+func (r *Region) Available() bool {
+	return r.Limit > 0
+}
+
+func (r *Region) String() string {
+	return fmt.Sprintf("[%#x, %#x)", r.Base, r.Limit)
+}
+
+// BaseOffset calculates the offset into the flash image where the Region begins
+func (r *Region) BaseOffset() uint32 {
+	return uint32(r.Base) * RegionBlockSize
+}
+
+// EndOffset calculates the offset into the flash image where the Region ends
+func (r *Region) EndOffset() uint32 {
+	return (uint32(r.Limit) + 1) * RegionBlockSize
+}


### PR DESCRIPTION
This rearranges so that the Flash type basically contains the IFD and 4 regions.  This makes it easier to extract and more logically separates the regions.