### PR TITLE
Make all methods pointer receivers

### DIFF
--- a/uefi/biosregion.go
+++ b/uefi/biosregion.go
@@ -20,7 +20,7 @@ type BIOSRegion struct {
 }
 
 // Summary prints a multi-line description of the Bios Region
-func (br BIOSRegion) Summary() string {
+func (br *BIOSRegion) Summary() string {
 	var fvols []string
 	for _, fv := range br.FirmwareVolumes {
 		fvols = append(fvols, fv.Summary())

--- a/uefi/firmwarevolume.go
+++ b/uefi/firmwarevolume.go
@@ -63,7 +63,7 @@ type FirmwareVolume struct {
 }
 
 // Summary prints a multi-line representation of a FirmwareVolume object
-func (fv FirmwareVolume) Summary() string {
+func (fv *FirmwareVolume) Summary() string {
 	return fmt.Sprintf("FirmwareVolume{\n"+
 		"    FileSystemGUID=%s (%v)\n"+
 		"    Length=%v\n"+

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -52,14 +52,14 @@ type FlashImage struct {
 // PCH images have the first 16 bytes reserved, and the 4-bytes signature starts
 // immediately after. Older images (ICH8/9/10) have the signature at the
 // beginning.
-func (f FlashImage) IsPCH() bool {
+func (f *FlashImage) IsPCH() bool {
 	return bytes.Equal(f.buf[16:16+len(FlashSignature)], FlashSignature)
 }
 
 // FindSignature looks for the Intel flash signature, and returns its offset
 // from the start of the image. The PCH images are located at offset 16, while
 // in ICH8/9/10 they start at 0. If no signature is found, it returns -1.
-func (f FlashImage) FindSignature() (int, error) {
+func (f *FlashImage) FindSignature() (int, error) {
 	if bytes.Equal(f.buf[16:16+len(FlashSignature)], FlashSignature) {
 		// 16 + 4 since the descriptor starts after the signature
 		return 20, nil
@@ -73,7 +73,7 @@ func (f FlashImage) FindSignature() (int, error) {
 
 // Validate runs a set of checks on the flash image and returns a list of
 // errors specifying what is wrong.
-func (f FlashImage) Validate() []error {
+func (f *FlashImage) Validate() []error {
 	errors := make([]error, 0)
 	_, err := f.FindSignature()
 	if err != nil {
@@ -84,7 +84,7 @@ func (f FlashImage) Validate() []error {
 	return errors
 }
 
-func (f FlashImage) String() string {
+func (f *FlashImage) String() string {
 	return fmt.Sprintf("FlashImage{Size=%v, Descriptor=%v, Region=%v, Master=%v}",
 		len(f.buf),
 		f.IFD.DescriptorMap.String(),
@@ -94,7 +94,7 @@ func (f FlashImage) String() string {
 }
 
 // Summary prints a multi-line description of the flash image
-func (f FlashImage) Summary() string {
+func (f *FlashImage) Summary() string {
 	return fmt.Sprintf("FlashImage{\n"+
 		"    Size=%v\n"+
 		"    DescriptorMapStart=%v\n"+

--- a/uefi/flashdescriptormap.go
+++ b/uefi/flashdescriptormap.go
@@ -55,7 +55,7 @@ func NewFlashDescriptorMap(buf []byte) (*FlashDescriptorMap, error) {
 	return &descriptor, nil
 }
 
-func (d FlashDescriptorMap) String() string {
+func (d *FlashDescriptorMap) String() string {
 	return fmt.Sprintf("FlashDescriptorMap{NumberOfRegions=%v, NumberOfFlashChips=%v, NumberOfMasters=%v, NumberOfPCHStraps=%v, NumberOfProcessorStraps=%v, NumberOfICCTableEntries=%v, DMITableEntries=%v}",
 		d.NumberOfRegions,
 		d.NumberOfFlashChips,
@@ -68,7 +68,7 @@ func (d FlashDescriptorMap) String() string {
 }
 
 // Summary prints a multi-line description of the flash descriptor map
-func (d FlashDescriptorMap) Summary() string {
+func (d *FlashDescriptorMap) Summary() string {
 	return fmt.Sprintf("FlashDescriptorMap{\n"+
 		"    ComponentBase=%v (0x%02x)\n"+
 		"    NumberOfFlashChips=%v (0x%02x)\n"+
@@ -104,7 +104,7 @@ func (d FlashDescriptorMap) Summary() string {
 
 // Validate runs a set of checks on the flash descriptor and returns a list of
 // errors specifying what is wrong.
-func (d FlashDescriptorMap) Validate() []error {
+func (d *FlashDescriptorMap) Validate() []error {
 	errors := make([]error, 0)
 	if d.MasterBase > FlashDescriptorMapMaxBase {
 		errors = append(errors, fmt.Errorf("MasterBase too large: expected %v bytes, got %v",

--- a/uefi/flashmastersection.go
+++ b/uefi/flashmastersection.go
@@ -16,7 +16,7 @@ type RegionPermissions struct {
 	Write uint8
 }
 
-func (r RegionPermissions) String() string {
+func (r *RegionPermissions) String() string {
 	return fmt.Sprintf("RegionPermissions{ID=%v, Read=0x%x, Write=0x%x}",
 		r.ID, r.Read, r.Write)
 }
@@ -29,13 +29,13 @@ type FlashMasterSection struct {
 	GBE  RegionPermissions
 }
 
-func (m FlashMasterSection) String() string {
+func (m *FlashMasterSection) String() string {
 	return fmt.Sprintf("FlashMasterSection{Bios %v, Me %v, Gbe %v}",
 		m.BIOS, m.ME, m.GBE)
 }
 
 // Summary prints a multi-line description of the FlashMasterSection
-func (m FlashMasterSection) Summary() string {
+func (m *FlashMasterSection) Summary() string {
 	return fmt.Sprintf("FlashMasterSection{\n"+
 		"    BiosID=%v\n"+
 		"    BiosRead=%v\n"+

--- a/uefi/flashparams.go
+++ b/uefi/flashparams.go
@@ -34,51 +34,51 @@ var FlashFrequencyStringMap = map[FlashFrequency]string{
 type FlashParams [4]byte
 
 // FirstChipDensity returns the size of the first chip.
-func (p FlashParams) FirstChipDensity() uint {
+func (p *FlashParams) FirstChipDensity() uint {
 	return uint(p[0] & 0x0f)
 }
 
 // SecondChipDensity returns the size of the second chip.
-func (p FlashParams) SecondChipDensity() uint {
+func (p *FlashParams) SecondChipDensity() uint {
 	return uint((p[0] >> 4) & 0x0f)
 }
 
 // ReadClockFrequency returns the chip frequency while reading from the flash.
-func (p FlashParams) ReadClockFrequency() FlashFrequency {
+func (p *FlashParams) ReadClockFrequency() FlashFrequency {
 	return FlashFrequency((p[2] >> 1) & 0x07)
 }
 
 // FastReadEnabled returns if FastRead is enabled.
-func (p FlashParams) FastReadEnabled() uint {
+func (p *FlashParams) FastReadEnabled() uint {
 	return uint((p[2] >> 4) & 0x01)
 }
 
 // FastReadFrequency returns the frequency under FastRead.
-func (p FlashParams) FastReadFrequency() FlashFrequency {
+func (p *FlashParams) FastReadFrequency() FlashFrequency {
 	return FlashFrequency((p[2] >> 5) & 0x07)
 }
 
 // FlashWriteFrequency returns the chip frequency for writing.
-func (p FlashParams) FlashWriteFrequency() FlashFrequency {
+func (p *FlashParams) FlashWriteFrequency() FlashFrequency {
 	return FlashFrequency(p[3] & 0x07)
 }
 
 // FlashReadStatusFrequency returns the chip frequency while reading the flash status.
-func (p FlashParams) FlashReadStatusFrequency() FlashFrequency {
+func (p *FlashParams) FlashReadStatusFrequency() FlashFrequency {
 	return FlashFrequency((p[3] >> 3) & 0x07)
 }
 
 // DualOutputFastReadSupported returns if Dual Output Fast Read is supported.
-func (p FlashParams) DualOutputFastReadSupported() uint {
+func (p *FlashParams) DualOutputFastReadSupported() uint {
 	return uint(p[3] >> 7)
 }
 
-func (p FlashParams) String() string {
+func (p *FlashParams) String() string {
 	return fmt.Sprintf("FlashParams{...}")
 }
 
 // Summary prints a multi-line description of the FlashParams
-func (p FlashParams) Summary() string {
+func (p *FlashParams) Summary() string {
 	rcf, ok := FlashFrequencyStringMap[p.ReadClockFrequency()]
 	if !ok {
 		rcf = fmt.Sprintf("Unknown (%v)", p.ReadClockFrequency())

--- a/uefi/flashregionsection.go
+++ b/uefi/flashregionsection.go
@@ -21,7 +21,7 @@ type FlashRegionSection struct {
 }
 
 // ValidRegions returns a list of names of the regions with non-zero size.
-func (f FlashRegionSection) ValidRegions() []string {
+func (f *FlashRegionSection) ValidRegions() []string {
 	var regions []string
 	if f.BIOS.Valid() {
 		regions = append(regions, "BIOS")
@@ -38,14 +38,14 @@ func (f FlashRegionSection) ValidRegions() []string {
 	return regions
 }
 
-func (f FlashRegionSection) String() string {
+func (f *FlashRegionSection) String() string {
 	return fmt.Sprintf("FlashRegionSection{Regions=%v}",
 		strings.Join(f.ValidRegions(), ","),
 	)
 }
 
 // Summary prints a multi-line description of the FlashRegionSection
-func (f FlashRegionSection) Summary() string {
+func (f *FlashRegionSection) Summary() string {
 	return fmt.Sprintf("FlashRegionSection{\n"+
 		"    Regions=%v\n"+
 		"    Bios=%v\n"+


### PR DESCRIPTION
This avoids the copying done every time we call any method

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>