### PR TITLE
Clean up UUID code

### DIFF
--- a/uefi/firmwarevolume.go
+++ b/uefi/firmwarevolume.go
@@ -39,7 +39,7 @@ type Block struct {
 // header
 type FirmwareVolumeFixedHeader struct {
 	_               [16]uint8
-	FileSystemGUID  [16]uint8
+	FileSystemGUID  uuid.UUID
 	Length          uint64
 	Signature       uint32
 	Attributes      uint32 // UEFI PI spec volume 3.2.1 EFI_FIRMWARE_VOLUME_HEADER
@@ -54,7 +54,7 @@ type FirmwareVolumeFixedHeader struct {
 // FirmwareVolumeExtHeader contains the fields of an extended firmware volume
 // header
 type FirmwareVolumeExtHeader struct {
-	FVName        [16]uint8
+	FVName        uuid.UUID
 	ExtHeaderSize uint32
 }
 
@@ -132,15 +132,10 @@ func NewFirmwareVolume(data []byte) (*FirmwareVolume, error) {
 		}
 	}
 
-	if guid, err := uuid.FromBytes(fv.FileSystemGUID[:]); err == nil {
-		var ok bool
-		fv.guidString = guid.String()
-		fv.guidName, ok = FirmwareVolumeGUIDs[fv.guidString]
-		if !ok {
-			fv.guidName = "Unknown"
-		}
-	} else {
-		fv.guidString = "<invalid GUID>"
+	var ok bool
+	fv.guidString = fv.FileSystemGUID.String()
+	fv.guidName, ok = FirmwareVolumeGUIDs[fv.guidString]
+	if !ok {
 		fv.guidName = "Unknown"
 	}
 

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -1,0 +1,47 @@
+package uuid
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	// UUID examples
+	exampleUUID UUID = [16]byte{0x67, 0x45, 0x23, 0x01, 0xAB, 0x89, 0xEF, 0xCD,
+		0x23, 0x01, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+	// UUID string examples
+	exampleUUIDString   = "01234567-89AB-CDEF-0123-456789ABCDEF"
+	shortUUIDString     = "0123456789ABCDEF0123456789ABCDEF"
+	badUUIDStringLength = "01234567"
+	badHex              = "GHGHGHGHGHGHGH"
+)
+
+func TestParse(t *testing.T) {
+	var tests = []struct {
+		s   string
+		u   *UUID
+		msg string
+	}{
+		{exampleUUIDString, &exampleUUID, ""},
+		{shortUUIDString, &exampleUUID, ""},
+		{badUUIDStringLength, nil, fmt.Sprintf("uuid string has incorrect length, need string of the format \n%v\n, got \n%v",
+			UExample, badUUIDStringLength)},
+		{badHex, nil, fmt.Sprintf("uuid string not correct, need string of the format \n%v\n, got \n%v",
+			UExample, badHex)},
+	}
+	for _, test := range tests {
+		u, err := Parse(test.s)
+		if u == nil {
+			if test.u != nil {
+				t.Errorf("UUID was expected: %v, got nil", test.u)
+			}
+			if err == nil {
+				t.Errorf("Error was not returned, expected %v", test.msg)
+			} else if err.Error() != test.msg {
+				t.Errorf("Mismatched Error returned, expected \n%v\n got \n%v\n", test.msg, err.Error())
+			}
+		} else if *u != *test.u {
+			t.Errorf("UUID was parsed incorrectly, expected %v\n, got %v\n, string was %v", test.u, u, test.s)
+		}
+	}
+}


### PR DESCRIPTION
Clean up parsing and String functions, as well as use UUID type in
headers rather than maintaining a separate guid.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>

This needs to be rebased on top of #15, I basically need to make the same change for firmwarefile.go. Do not merge, but please review.