### PR TITLE
Add validate functions for FVs

### DIFF
--- a/uefi/biosregion.go
+++ b/uefi/biosregion.go
@@ -56,6 +56,9 @@ func (br *BIOSRegion) Validate() []error {
 	if len(br.FirmwareVolumes) == 0 {
 		errs = append(errs, errors.New("no firmware volumes in BIOS Region"))
 	}
+	for _, fv := range br.FirmwareVolumes {
+		errs = append(errs, fv.Validate()...)
+	}
 	return errs
 }
 

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -106,6 +106,7 @@ func (f *FlashImage) Validate() []error {
 	}
 	errors = append(errors, f.IFD.DescriptorMap.Validate()...)
 	// TODO also validate regions, masters, etc
+	errors = append(errors, f.BIOS.Validate()...)
 	return errors
 }
 


### PR DESCRIPTION
Also call validate functions for biosregion, we weren't calling it
earlier.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>