### PR TITLE
Make Parse, Extract and Assemble more generic

### DIFF
--- a/uefi/biosregion.go
+++ b/uefi/biosregion.go
@@ -51,10 +51,7 @@ func NewBIOSRegion(buf []byte, r *Region) (*BIOSRegion, error) {
 func (br *BIOSRegion) Validate() []error {
 	// TODO: Add more verification if needed.
 	errs := make([]error, 0)
-	if br.Position == nil {
-		errs = append(errs, errors.New("BIOSRegion position is nil"))
-	}
-	if !br.Position.Valid() {
+	if br.Position != nil && !br.Position.Valid() {
 		errs = append(errs, fmt.Errorf("BIOSRegion is not valid, region was %v", *br.Position))
 	}
 	if len(br.FirmwareVolumes) == 0 {

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -3,7 +3,6 @@ package uefi
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -194,14 +193,7 @@ func (f *FlashImage) Extract(dirPath string) error {
 		}
 	}
 
-	// Output summary json. This must be done after all other extract calls so that
-	// any metadata fields in sub structures are generated properly.
-	jsonPath := filepath.Join(absDirPath, "summary.json")
-	b, err := json.MarshalIndent(f, "", "    ")
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(jsonPath, b, 0666)
+	return nil
 }
 
 // Assemble assembles the FlashImage starting from the bottom up.

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -39,7 +39,8 @@ type FlashDescriptor struct {
 	ExtractPath string
 }
 
-func findSignature(buf []byte) (int, error) {
+// FindSignature searchs for an Intel flash signature.
+func FindSignature(buf []byte) (int, error) {
 	if bytes.Equal(buf[16:16+FlashSignatureLength], FlashSignature) {
 		// 16 + 4 since the descriptor starts after the signature
 		return 20, nil
@@ -58,7 +59,7 @@ func (fd *FlashDescriptor) ParseFlashDescriptor() error {
 		return fmt.Errorf("flash descriptor length not %#x, was %#x", FlashDescriptorLength, buflen)
 	}
 
-	descriptorMapStart, err := findSignature(fd.buf)
+	descriptorMapStart, err := FindSignature(fd.buf)
 	if err != nil {
 		return err
 	}
@@ -157,7 +158,7 @@ func (f *FlashImage) IsPCH() bool {
 // from the start of the image. The PCH images are located at offset 16, while
 // in ICH8/9/10 they start at 0. If no signature is found, it returns -1.
 func (f *FlashImage) FindSignature() (int, error) {
-	return findSignature(f.buf)
+	return FindSignature(f.buf)
 }
 
 // Validate runs a set of checks on the flash image and returns a list of

--- a/uefi/uefi.go
+++ b/uefi/uefi.go
@@ -22,14 +22,13 @@ type Firmware interface {
 // implement any parser itself, but it calls known parsers that implement the
 // Firmware interface.
 func Parse(buf []byte) (Firmware, error) {
-	switch {
-	case len(buf) >= 20 && bytes.Equal(buf[16:16+len(FlashSignature)], FlashSignature):
+	if _, err := FindSignature(buf); err == nil {
+		// Intel rom.
 		return NewFlashImage(buf)
-	case bytes.Equal(buf[:len(FlashSignature)], FlashSignature):
-		return NewFlashImage(buf)
-	default:
-		return nil, fmt.Errorf("Unknown firmware type")
 	}
+	// Non intel image such as edk2's OVMF
+	// We don't know how to parse this header, so treat it as a large BIOSRegion
+	return NewBIOSRegion(buf, nil)
 }
 
 // ExtractBinary simply dumps the binary to a specified directory and filename.


### PR DESCRIPTION
This change should allow for handling firmware images with no IFD, such as AMD images and EDK2's OVMF roms. Once this is merged we can finally add an integration test that will pull apart an OVMF binary and reassemble it and check that it's identical.

This change allows for a BIOS region to not hold a Region pointer, and helps the assembly by storing the type of the firmware element at the top.