### PR TITLE
Add warn flag for validate

### DIFF
--- a/utk/utk.go
+++ b/utk/utk.go
@@ -16,6 +16,7 @@ import (
 
 // Parse subcommand
 type parseCmd struct {
+	warn bool
 }
 
 func (*parseCmd) Name() string {
@@ -30,9 +31,11 @@ func (*parseCmd) Usage() string {
 	return "parse <path-to-rom-file>\n"
 }
 
-func (*parseCmd) SetFlags(_ *flag.FlagSet) {}
+func (p *parseCmd) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&p.warn, "warn", false, "warn instead of fail on validation errors")
+}
 
-func (*parseCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *parseCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	args := f.Args()
 	if len(args) == 0 {
 		log.Print("A file name is required")
@@ -55,7 +58,8 @@ func (*parseCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	for _, err := range errlist {
 		log.Printf("Error found: %v\n", err.Error())
 	}
-	if len(errlist) > 0 {
+	errlen := len(errlist)
+	if !p.warn && errlen > 0 {
 		return subcommands.ExitFailure
 	}
 
@@ -65,12 +69,16 @@ func (*parseCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 		return subcommands.ExitFailure
 	}
 	fmt.Println(string(b))
+	if errlen > 0 {
+		return subcommands.ExitFailure
+	}
 	return subcommands.ExitSuccess
 }
 
 // Extract subcommand
 type extractCmd struct {
 	force bool
+	warn  bool
 }
 
 func (*extractCmd) Name() string {
@@ -87,6 +95,7 @@ func (*extractCmd) Usage() string {
 
 func (e *extractCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&e.force, "force", false, "force extract to non empty directory")
+	f.BoolVar(&e.warn, "warn", false, "warn instead of fail on validation errors")
 }
 
 func (e *extractCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -112,7 +121,8 @@ func (e *extractCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	for _, err := range errlist {
 		log.Printf("Error found: %v\n", err.Error())
 	}
-	if len(errlist) > 0 {
+	errlen := len(errlist)
+	if !e.warn && errlen > 0 {
 		return subcommands.ExitFailure
 	}
 
@@ -134,6 +144,10 @@ func (e *extractCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	err = flash.Extract(args[1])
 	if err != nil {
 		log.Print(err)
+		return subcommands.ExitFailure
+	}
+	if errlen > 0 {
+		// Return failure even if warn is set.
 		return subcommands.ExitFailure
 	}
 	return subcommands.ExitSuccess


### PR DESCRIPTION
The OVMF.fd nvram file seems to have an invalid checksum. This will allow extraction to still continue so we can get some hierarchy information from the json.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>