### PR TITLE
Integration tests

### DIFF
--- a/integration/roms/.gitignore
+++ b/integration/roms/.gitignore
@@ -1,0 +1,2 @@
+# This prevents you from accidentally committing proprietary ROMs.
+SECRET*

--- a/integration/roms/OVMF.md
+++ b/integration/roms/OVMF.md
@@ -1,0 +1,24 @@
+# OVMF
+
+EDK2 is open-source UEFI firmware, governed under a BSD license and can be
+redistributed. OVMF is a EDK2 configuration which can run under QEMU.
+
+In this folder, you will find:
+
+- `OVMF.rom`: EDK2 firmware image
+- `OVMF_target.txt`: Configuration used to build the OVMF image. To rebuild,
+  copy this file to `conf/target.txt` in the EDK2 source tree.
+
+
+## Build Notes
+
+- OS: `Ubuntu 16.04.4 LTS xenial`
+- Git tag: `vUDK2018`
+- GCC version: `gcc (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609`
+- Build is not reproducible.
+- Find instructions at: https://wiki.ubuntu.com/UEFI/EDK2
+
+
+## Running in QEMU
+
+    qemu-system-x86_64 -bios OVMF.rom -nographic -net none

--- a/integration/roms/OVMF_target.txt
+++ b/integration/roms/OVMF_target.txt
@@ -1,0 +1,76 @@
+#
+#  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+#
+#  This program and the accompanying materials
+#  are licensed and made available under the terms and conditions of the BSD License
+#  which accompanies this distribution.  The full text of the license may be found at
+#  http://opensource.org/licenses/bsd-license.php
+
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+#
+#  ALL Paths are Relative to WORKSPACE
+
+#  Separate multiple LIST entries with a SINGLE SPACE character, do not use comma characters.
+#  Un-set an option by either commenting out the line, or not setting a value.
+
+#
+#  PROPERTY              Type       Use         Description
+#  ----------------      --------   --------    -----------------------------------------------------------
+#  ACTIVE_PLATFORM       Filename   Recommended Specify the WORKSPACE relative Path and Filename
+#                                               of the platform description file that will be used for the
+#                                               build. This line is required if and only if the current
+#                                               working directory does not contain one or more description
+#                                               files.
+ACTIVE_PLATFORM       = OvmfPkg/OvmfPkgX64.dsc
+
+#  TARGET                List       Optional    Zero or more of the following: DEBUG, RELEASE, NOOPT
+#                                               UserDefined; separated by a space character.
+#                                               If the line is missing or no value is specified, all
+#                                               valid targets specified in the platform description file
+#                                               will attempt to be built. The following line will build
+#                                               DEBUG platform target.
+TARGET                = DEBUG
+
+#  TARGET_ARCH           List       Optional    What kind of architecture is the binary being target for.
+#                                               One, or more, of the following, IA32, IPF, X64, EBC, ARM
+#                                               or AArch64.
+#                                               Multiple values can be specified on a single line, using
+#                                               space charaters to separate the values.  These are used
+#                                               during the parsing of a platform description file,
+#                                               restricting the build output target(s.)
+#                                               The Build Target ARCH is determined by (precedence high to low):
+#                                                 Command-line: -a ARCH option
+#                                                 target.txt: TARGET_ARCH values
+#                                                 DSC file: [Defines] SUPPORTED_ARCHITECTURES tag
+#                                               If not specified, then all valid architectures specified
+#                                               in the platform file, for which tools are available, will be
+#                                               built.
+TARGET_ARCH           = X64
+
+#  TOOL_DEFINITION_FILE  Filename  Optional   Specify the name of the filename to use for specifying
+#                                             the tools to use for the build.  If not specified,
+#                                             WORKSPACE/Conf/tools_def.txt will be used for the build.
+TOOL_CHAIN_CONF       = Conf/tools_def.txt
+
+#  TAGNAME               List      Optional   Specify the name(s) of the tools_def.txt TagName to use.
+#                                             If not specified, all applicable TagName tools will be
+#                                             used for the build.  The list uses space character separation.
+TOOL_CHAIN_TAG        = GCC5
+
+# MAX_CONCURRENT_THREAD_NUMBER  NUMBER  Optional  The number of concurrent threads. If not specified or set
+#                                                 to zero, tool automatically detect number of processor
+#                                                 threads. Recommend to set this value to one less than the
+#                                                 number of your computer cores or CPUs. When value set to 1,
+#                                                 means disable multi-thread build, value set to more than 1,
+#                                                 means user specify the thread number to build. Not specify
+#                                                 the default value in this file.
+# MAX_CONCURRENT_THREAD_NUMBER = 1
+
+
+# BUILD_RULE_CONF  Filename Optional  Specify the file name to use for the build rules that are followed
+#                                     when generating Makefiles. If not specified, the file:
+#                                     WORKSPACE/Conf/build_rule.txt will be used
+BUILD_RULE_CONF = Conf/build_rule.txt
+

--- a/integration/utk_test.go
+++ b/integration/utk_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Returns all the ROM names (files which end in .rom) inside the roms folder.
+func romList(t *testing.T) []string {
+	roms, err := filepath.Glob("roms/*.rom")
+	if err != nil {
+		t.Fatalf("could not glob roms/*.rom, %v", err)
+	}
+	if len(roms) == 0 {
+		t.Fatal("no ROMs found with roms/*.rom")
+	}
+	return roms
+}
+
+// Builds UTK into temporary directory.
+func buildUTK(t *testing.T) (tmpDir string, utk string) {
+	// Create temporary directory for test files.
+	var err error
+	tmpDir, err = ioutil.TempDir("", "utk-test")
+	if err != nil {
+		t.Fatalf("could not create temp dir: %v", err)
+	}
+
+	// Build UTK in the tmpDir.
+	cmd := exec.Command("go", "build", "github.com/linuxboot/fiano/utk")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatalf("could not build UTK: %v", err)
+	}
+	utk = filepath.Join(tmpDir, "utk")
+
+	return
+}
+
+// TestParse tests the parse subcommand of UTK. The amount of testing is
+// negligible. This simply tests that valid ROMs produce valid JSON. Warnings
+// are printed but ignored.
+func TestParse(t *testing.T) {
+	// Build UTK.
+	tmpDir, utk := buildUTK(t)
+	defer os.RemoveAll(tmpDir)
+
+	for _, tt := range romList(t) {
+		t.Run(tt, func(t *testing.T) {
+			// Run `utk parse --warn tt.rom`.
+			cmd := exec.Command(utk, "parse", "--warn", tt)
+			cmd.Stderr = os.Stderr
+			out, err := cmd.Output()
+
+			// Warnings are acceptable as long as valid JSON is outputted.
+			if err != nil {
+				t.Log("non-zero exit status returned")
+			}
+
+			var dec interface{}
+			err = json.Unmarshal(out, &dec)
+			if err != nil {
+				t.Errorf("invalid json: %q", string(out))
+			}
+		})
+	}
+}
+
+// TestExtractAssembleExtract tests the extract and assemble subcommand of UTK.
+// The subcommands are run in this order:
+//
+// 1. utk extract tt.rom dir1
+// 2. utk assemble dir1 tmp.rom
+// 3. utk extract tmp.rom dir2
+//
+// The test passes iff the contents or dir1 and dir2 recursively equal. This
+// roundabout method is used because UTK can re-assemble a ROM image which is
+// logically equal to the original, but not bitwise equal (due to a different
+// compression algorithm being used). To compare the ROMs logically, step 3 is
+// required to decompresses it.
+func TestExtractAssembleExtract(t *testing.T) {
+	// Build UTK.
+	tmpDir, utk := buildUTK(t)
+	defer os.RemoveAll(tmpDir)
+
+	for _, tt := range romList(t) {
+		t.Run(tt, func(t *testing.T) {
+			// Test paths
+			var (
+				dir1   = filepath.Join(tmpDir, "dir1")
+				tmpRom = filepath.Join(tmpDir, "tmp.rom")
+				dir2   = filepath.Join(tmpDir, "dir2")
+			)
+
+			// Warnings are acceptable.
+			cmd := exec.Command(utk, "extract", "--warn", tt, dir1)
+			cmd.Stderr = os.Stderr
+			cmd.Run()
+			cmd = exec.Command(utk, "assemble", dir1, tmpRom)
+			cmd.Stderr = os.Stderr
+			cmd.Run()
+			cmd = exec.Command(utk, "extract", "--warn", tmpRom, dir2)
+			cmd.Stderr = os.Stderr
+			cmd.Run()
+
+			// Output directories must not be empty.
+			for _, d := range []string{dir1, dir2} {
+				files, err := ioutil.ReadDir(d)
+				if err != nil {
+					t.Fatalf("cannot read directory %q: %v", d, err)
+				}
+				if len(files) == 0 {
+					t.Errorf("no files in directory %q", d)
+				}
+			}
+
+			// TODO: make summary.json paths relative so this hack can be removed.
+			exec.Command("sed", "-i", "s/dir2/dir1/", filepath.Join(dir2, "summary.json")).Run()
+
+			// Recursively test for equality.
+			cmd = exec.Command("diff", "-r", dir1, dir2)
+			cmd.Stderr = os.Stderr
+			cmd.Stdout = os.Stdout
+			if err := cmd.Run(); err != nil {
+				t.Error("directories did not recursively compare equal")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Feel free to add more ROMs to `integration/roms`. The test uses all ROMs in that directory which end in `.rom`. ROMs which begin with `SECRET` are gitignore'd.

Right now, the test fails because there is a difference:

```
Binary files /tmp/utk-test631886125/dir1/bios/0x0/fv.bin and /tmp/utk-test631886125/dir2/bios/0x0/fv.bin differ
Binary files /tmp/utk-test631886125/dir1/bios/biosregion.bin and /tmp/utk-test631886125/dir2/bios/biosregion.bin differ
```

I will look more into why the difference exists later this week with vbindiff.