### PR TITLE
Don't output size and checksum fields for files.

### DIFF
--- a/uefi/filesection.go
+++ b/uefi/filesection.go
@@ -19,7 +19,7 @@ type SectionType uint8
 // FileSectionHeader represents an EFI_COMMON_SECTION_HEADER as specified in
 // UEFI PI Spec 3.2.4 Firmware File Section
 type FileSectionHeader struct {
-	Size [3]uint8
+	Size [3]uint8 `json:"-"`
 	Type SectionType
 }
 
@@ -27,7 +27,7 @@ type FileSectionHeader struct {
 // UEFI PI Spec 3.2.4 Firmware File Section
 type FileSectionExtHeader struct {
 	FileSectionHeader
-	ExtendedSize uint32
+	ExtendedSize uint32 `json:"-"`
 }
 
 // FileSection represents a Firmware File Section

--- a/uefi/firmwarefile.go
+++ b/uefi/firmwarefile.go
@@ -76,11 +76,11 @@ type fileAttr uint8
 
 // FirmwareFileHeader represents an EFI File header.
 type FirmwareFileHeader struct {
-	Name       uuid.UUID // This is the GUID of the file.
-	Checksum   IntegrityCheck
+	Name       uuid.UUID      // This is the GUID of the file.
+	Checksum   IntegrityCheck `json:"-"`
 	Type       FVFileType
 	Attributes fileAttr
-	Size       [3]uint8
+	Size       [3]uint8 `json:"-"`
 	State      uint8
 }
 
@@ -125,13 +125,13 @@ func (f *FirmwareFile) checksumHeader() uint8 {
 // All sizes are also copied into the ExtendedSize field so we only have to check once
 type FirmwareFileHeaderExtended struct {
 	FirmwareFileHeader
-	ExtendedSize uint64
+	ExtendedSize uint64 `json:"-"`
 }
 
 // FirmwareFile represents an EFI File.
 type FirmwareFile struct {
 	Header   FirmwareFileHeaderExtended
-	Sections []*FileSection
+	Sections []*FileSection `json:",omitempty"`
 
 	//Metadata for extraction and recovery
 	buf         []byte

--- a/uefi/firmwarevolume.go
+++ b/uefi/firmwarevolume.go
@@ -103,7 +103,7 @@ type FirmwareVolume struct {
 	// We don't really have to care about blocks because we just read everything in.
 	Blocks []Block
 	FirmwareVolumeExtHeader
-	Files []*FirmwareFile
+	Files []*FirmwareFile `json:",omitempty"`
 
 	// Variables not in the binary for us to keep track of stuff/print
 	DataOffset  uint64


### PR DESCRIPTION
These are expected to change on assembly, there is no sense for the user
to modify these fields.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>