### PR TITLE
visitor: Simplify the interface with type switch

### DIFF
--- a/uefi/biosregion.go
+++ b/uefi/biosregion.go
@@ -52,13 +52,13 @@ func NewBIOSRegion(buf []byte, r *Region) (*BIOSRegion, error) {
 
 // Apply calls the visitor on the BIOSRegion.
 func (br *BIOSRegion) Apply(v Visitor) error {
-	return v.VisitBIOSRegion(br)
+	return v.Visit(br)
 }
 
 // ApplyChildren calls the visitor on each child node of BIOSRegion.
 func (br *BIOSRegion) ApplyChildren(v Visitor) error {
 	for _, fv := range br.FirmwareVolumes {
-		if err := v.VisitFV(fv); err != nil {
+		if err := fv.Apply(v); err != nil {
 			return err
 		}
 	}

--- a/uefi/file.go
+++ b/uefi/file.go
@@ -185,13 +185,13 @@ type File struct {
 
 // Apply calls the visitor on the File.
 func (f *File) Apply(v Visitor) error {
-	return v.VisitFile(f)
+	return v.Visit(f)
 }
 
 // ApplyChildren calls the visitor on each child node of File.
 func (f *File) ApplyChildren(v Visitor) error {
 	for _, s := range f.Sections {
-		if err := v.VisitSection(s); err != nil {
+		if err := s.Apply(v); err != nil {
 			return err
 		}
 	}

--- a/uefi/firmwarevolume.go
+++ b/uefi/firmwarevolume.go
@@ -100,13 +100,13 @@ type FirmwareVolume struct {
 
 // Apply calls the visitor on the FirmwareVolume.
 func (fv *FirmwareVolume) Apply(v Visitor) error {
-	return v.VisitFV(fv)
+	return v.Visit(fv)
 }
 
 // ApplyChildren calls the visitor on each child node of FirmwareVolume.
 func (fv *FirmwareVolume) ApplyChildren(v Visitor) error {
 	for _, f := range fv.Files {
-		if err := v.VisitFile(f); err != nil {
+		if err := f.Apply(v); err != nil {
 			return err
 		}
 	}

--- a/uefi/flash.go
+++ b/uefi/flash.go
@@ -54,7 +54,7 @@ func FindSignature(buf []byte) (int, error) {
 
 // Apply calls the visitor on the FlashDescriptor.
 func (fd *FlashDescriptor) Apply(v Visitor) error {
-	return v.VisitIFD(fd)
+	return v.Visit(fd)
 }
 
 // ApplyChildren calls the visitor on each child node of FlashDescriptor.
@@ -153,28 +153,28 @@ type FlashImage struct {
 
 // Apply calls the visitor on the FlashImage.
 func (f *FlashImage) Apply(v Visitor) error {
-	return v.VisitImage(f)
+	return v.Visit(f)
 }
 
 // ApplyChildren calls the visitor on each child node of FlashImage.
 func (f *FlashImage) ApplyChildren(v Visitor) error {
 	if f.BIOS != nil {
-		if err := v.VisitBIOSRegion(f.BIOS); err != nil {
+		if err := f.BIOS.Apply(v); err != nil {
 			return err
 		}
 	}
 	if f.ME != nil {
-		if err := v.VisitMERegion(f.ME); err != nil {
+		if err := f.ME.Apply(v); err != nil {
 			return err
 		}
 	}
 	if f.GBE != nil {
-		if err := v.VisitGBERegion(f.GBE); err != nil {
+		if err := f.GBE.Apply(v); err != nil {
 			return err
 		}
 	}
 	if f.PD != nil {
-		if err := v.VisitPDRegion(f.PD); err != nil {
+		if err := f.PD.Apply(v); err != nil {
 			return err
 		}
 	}

--- a/uefi/gberegion.go
+++ b/uefi/gberegion.go
@@ -27,7 +27,7 @@ func NewGBERegion(buf []byte, r *Region) (*GBERegion, error) {
 
 // Apply calls the visitor on the GBERegion.
 func (gbe *GBERegion) Apply(v Visitor) error {
-	return v.VisitGBERegion(gbe)
+	return v.Visit(gbe)
 }
 
 // ApplyChildren calls the visitor on each child node of GBERegion.

--- a/uefi/meregion.go
+++ b/uefi/meregion.go
@@ -27,7 +27,7 @@ func NewMERegion(buf []byte, r *Region) (*MERegion, error) {
 
 // Apply calls the visitor on the MERegion.
 func (me *MERegion) Apply(v Visitor) error {
-	return v.VisitMERegion(me)
+	return v.Visit(me)
 }
 
 // ApplyChildren calls the visitor on each child node of MERegion.

--- a/uefi/pdregion.go
+++ b/uefi/pdregion.go
@@ -27,7 +27,7 @@ func NewPDRegion(buf []byte, r *Region) (*PDRegion, error) {
 
 // Apply calls the visitor on the PDRegion.
 func (pd *PDRegion) Apply(v Visitor) error {
-	return v.VisitPDRegion(pd)
+	return v.Visit(pd)
 }
 
 // ApplyChildren calls the visitor on each child node of PDRegion.

--- a/uefi/section.go
+++ b/uefi/section.go
@@ -122,7 +122,7 @@ type Section struct {
 
 // Apply calls the visitor on the Section.
 func (s *Section) Apply(v Visitor) error {
-	return v.VisitSection(s)
+	return v.Visit(s)
 }
 
 // ApplyChildren calls the visitor on each child node of Section.

--- a/uefi/visitor.go
+++ b/uefi/visitor.go
@@ -1,28 +1,25 @@
 package uefi
 
-// Visitor represents an operation which can be applied to the Firmware. To
-// implement a visitor, implement a method for each concrete Firmware type you
-// want to visit. The remaining nodes can be recursed over automatically with:
+// Visitor represents an operation which can be applied to the Firmware.
+// Typically, the Visit function contains a type switch for the different
+// firmware types and a default case. For example:
 //
-//     func (v *Find) VisitFV(fv *uefi.FirmwareVolume) error {
-//             return fv.ApplyChildren(v)
+// func (v *Example) Visit(f uefi.Firmware) error {
+//     switch f := f.(type) {
+//
+//     case *uefi.File:
+//         fmt.Println("f is a file")
+//         return f.ApplyChildren(v) // Children are recursed over
+//
+//     case *uefi.Section:
+//         fmt.Println("f is a section")
+//         return nil // Children are not visited
+//
+//     default:
+//         // The default action is to recurse over children.
+//         return f.ApplyChildren(v)
 //     }
-//
-// Or pruned with:
-//
-//     func (v *Find) VisitFV(fv *uefi.FirmwareVolume) error {
-//             return nil
-//     }
+// }
 type Visitor interface {
-	VisitImage(*FlashImage) error
-	VisitFV(*FirmwareVolume) error
-	VisitFile(*File) error
-	VisitSection(*Section) error
-
-	// Intel specific
-	VisitIFD(*FlashDescriptor) error
-	VisitBIOSRegion(*BIOSRegion) error
-	VisitMERegion(*MERegion) error
-	VisitGBERegion(*GBERegion) error
-	VisitPDRegion(*PDRegion) error
+	Visit(Firmware) error
 }

--- a/visitors/extract.go
+++ b/visitors/extract.go
@@ -14,7 +14,8 @@ type Extract struct {
 	DirPath string
 }
 
-func (v *Extract) extract(f uefi.Firmware) error {
+// Visit applies the Extract visitor to any Firmware type.
+func (v *Extract) Visit(f uefi.Firmware) error {
 	// Create the directory if it does not exist.
 	if err := os.MkdirAll(v.DirPath, 0755); err != nil {
 		return err
@@ -34,51 +35,6 @@ func (v *Extract) extract(f uefi.Firmware) error {
 		return err
 	}
 	return ioutil.WriteFile("summary.json", json, 0666)
-}
-
-// VisitImage applies the Extract visitor to FlashImage.
-func (v *Extract) VisitImage(i *uefi.FlashImage) error {
-	return v.extract(i)
-}
-
-// VisitFV applies the Extract visitor to FirmwareVolume.
-func (v *Extract) VisitFV(fv *uefi.FirmwareVolume) error {
-	return v.extract(fv)
-}
-
-// VisitFile applies the Extract visitor to File.
-func (v *Extract) VisitFile(f *uefi.File) error {
-	return v.extract(f)
-}
-
-// VisitSection applies the Extract visitor to Section.
-func (v *Extract) VisitSection(s *uefi.Section) error {
-	return v.extract(s)
-}
-
-// VisitIFD applies the Extract visitor on a FlashDescriptor.
-func (v *Extract) VisitIFD(fd *uefi.FlashDescriptor) error {
-	return v.extract(fd)
-}
-
-// VisitBIOSRegion applies the Extract visitor on a BIOSRegion.
-func (v *Extract) VisitBIOSRegion(br *uefi.BIOSRegion) error {
-	return v.extract(br)
-}
-
-// VisitMERegion applies the Extract visitor on a MERegion.
-func (v *Extract) VisitMERegion(me *uefi.MERegion) error {
-	return v.extract(me)
-}
-
-// VisitGBERegion applies the Extract visitor on a GBERegion.
-func (v *Extract) VisitGBERegion(gbe *uefi.GBERegion) error {
-	return v.extract(gbe)
-}
-
-// VisitPDRegion applies the Extract visitor on a PDRegion.
-func (v *Extract) VisitPDRegion(pd *uefi.PDRegion) error {
-	return v.extract(pd)
 }
 
 func init() {

--- a/visitors/find.go
+++ b/visitors/find.go
@@ -23,60 +23,30 @@ type Find struct {
 	currentFile *uefi.File
 }
 
-// VisitImage applies the Find visitor on a FlashImage.
-func (v *Find) VisitImage(i *uefi.FlashImage) error {
-	return i.ApplyChildren(v)
-}
+// Visit applies the Find visitor to any Firmware type.
+func (v *Find) Visit(f uefi.Firmware) error {
+	switch f := f.(type) {
 
-// VisitFV applies the Find visitor on a FirmwareVolume.
-func (v *Find) VisitFV(fv *uefi.FirmwareVolume) error {
-	return fv.ApplyChildren(v)
-}
+	case *uefi.File:
+		// Clone the visitor so the `currentFile` is passed only to descendents.
+		v2 := &Find{
+			Predicate:   v.Predicate,
+			currentFile: f,
+		}
+		err := f.ApplyChildren(v2)
+		v.Matches = append(v.Matches, v2.Matches...) // Merge together
+		return err
 
-// VisitFile applies the Find visitor on a File.
-func (v *Find) VisitFile(f *uefi.File) error {
-	// Clone the visitor so the `currentFile` is passed only to descendents.
-	v2 := &Find{
-		Predicate:   v.Predicate,
-		currentFile: f,
+	case *uefi.Section:
+		if v.currentFile != nil && v.Predicate(v.currentFile, f.Name) {
+			v.Matches = append(v.Matches, v.currentFile)
+			v.currentFile = nil // Do not double-match with a sibling.
+		}
+		return f.ApplyChildren(v)
+
+	default:
+		return f.ApplyChildren(v)
 	}
-	err := f.ApplyChildren(v2)
-	v.Matches = append(v.Matches, v2.Matches...) // Merge together
-	return err
-}
-
-// VisitSection applies the Find visitor on a Section.
-func (v *Find) VisitSection(s *uefi.Section) error {
-	if v.currentFile != nil && v.Predicate(v.currentFile, s.Name) {
-		v.Matches = append(v.Matches, v.currentFile)
-		v.currentFile = nil // Do not double-match with a sibling.
-	}
-	return s.ApplyChildren(v)
-}
-
-// VisitIFD applies the Find visitor on a FlashDescriptor.
-func (v *Find) VisitIFD(fd *uefi.FlashDescriptor) error {
-	return fd.ApplyChildren(v)
-}
-
-// VisitBIOSRegion applies the Find visitor on a BIOSRegion.
-func (v *Find) VisitBIOSRegion(br *uefi.BIOSRegion) error {
-	return br.ApplyChildren(v)
-}
-
-// VisitMERegion applies the Find visitor on a MERegion.
-func (v *Find) VisitMERegion(me *uefi.MERegion) error {
-	return me.ApplyChildren(v)
-}
-
-// VisitGBERegion applies the Find visitor on a GBERegion.
-func (v *Find) VisitGBERegion(gbe *uefi.GBERegion) error {
-	return gbe.ApplyChildren(v)
-}
-
-// VisitPDRegion applies the Find visitor on a PDRegion.
-func (v *Find) VisitPDRegion(pd *uefi.PDRegion) error {
-	return pd.ApplyChildren(v)
 }
 
 func init() {

--- a/visitors/json.go
+++ b/visitors/json.go
@@ -10,59 +10,14 @@ import (
 // JSON prints any Firmware node as JSON.
 type JSON struct{}
 
-// json package already operates recursively.
-func printJSON(ast uefi.Firmware) error {
-	b, err := json.MarshalIndent(ast, "", "\t")
+// Visit applies the JSON visitor to any Firmware type.
+func (v *JSON) Visit(f uefi.Firmware) error {
+	b, err := json.MarshalIndent(f, "", "\t")
 	if err != nil {
 		return err
 	}
 	fmt.Println(string(b))
 	return nil
-}
-
-// VisitImage applies the JSON visitor to FlashImage.
-func (v *JSON) VisitImage(i *uefi.FlashImage) error {
-	return printJSON(i)
-}
-
-// VisitFV applies the JSON visitor to FirmwareVolume.
-func (v *JSON) VisitFV(fv *uefi.FirmwareVolume) error {
-	return printJSON(fv)
-}
-
-// VisitFile applies the JSON visitor to File.
-func (v *JSON) VisitFile(f *uefi.File) error {
-	return printJSON(f)
-}
-
-// VisitSection applies the JSON visitor to Section.
-func (v *JSON) VisitSection(s *uefi.Section) error {
-	return printJSON(s)
-}
-
-// VisitIFD applies the JSON visitor on a FlashDescriptor.
-func (v *JSON) VisitIFD(fd *uefi.FlashDescriptor) error {
-	return printJSON(fd)
-}
-
-// VisitBIOSRegion applies the JSON visitor on a BIOSRegion.
-func (v *JSON) VisitBIOSRegion(br *uefi.BIOSRegion) error {
-	return printJSON(br)
-}
-
-// VisitMERegion applies the JSON visitor on a MERegion.
-func (v *JSON) VisitMERegion(me *uefi.MERegion) error {
-	return printJSON(me)
-}
-
-// VisitGBERegion applies the JSON visitor on a GBERegion.
-func (v *JSON) VisitGBERegion(gbe *uefi.GBERegion) error {
-	return printJSON(gbe)
-}
-
-// VisitPDRegion applies the JSON visitor on a PDRegion.
-func (v *JSON) VisitPDRegion(pd *uefi.PDRegion) error {
-	return printJSON(pd)
 }
 
 func init() {

--- a/visitors/table.go
+++ b/visitors/table.go
@@ -19,6 +19,33 @@ func indent(n int) string {
 	return strings.Repeat(" ", n)
 }
 
+// Visit applies the Table visitor to any Firmware type.
+func (v *Table) Visit(f uefi.Firmware) error {
+	switch f := f.(type) {
+	case *uefi.FlashImage:
+		return v.printRow(f, "Image", "", "", "")
+	case *uefi.FirmwareVolume:
+		return v.printRow(f, "FV", f.FileSystemGUID.String(), "", f.Length)
+	case *uefi.File:
+		// TODO: make name part of the file node
+		return v.printRow(f, "File", f.Header.UUID.String(), f.Header.Type, f.Header.ExtendedSize)
+	case *uefi.Section:
+		return v.printRow(f, "Sec", f.Name, f.Type, fmt.Sprintf("%d", f.Header.ExtendedSize))
+	case *uefi.FlashDescriptor:
+		return v.printRow(f, "IFD", "", "", "")
+	case *uefi.BIOSRegion:
+		return v.printRow(f, "BIOS", "", "", "")
+	case *uefi.MERegion:
+		return v.printRow(f, "ME", "", "", "")
+	case *uefi.GBERegion:
+		return v.printRow(f, "GBE", "", "", "")
+	case *uefi.PDRegion:
+		return v.printRow(f, "PD", "", "", "")
+	default:
+		return v.printRow(f, fmt.Sprintf("%T", f), "", "", "")
+	}
+}
+
 func (v *Table) printRow(f uefi.Firmware, node, name, typez, size interface{}) error {
 	if v.W == nil {
 		v.W = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -29,52 +56,6 @@ func (v *Table) printRow(f uefi.Firmware, node, name, typez, size interface{}) e
 	v2 := *v
 	v2.indent++
 	return f.ApplyChildren(&v2)
-}
-
-// VisitImage applies a Table visitor to FlashImage.
-func (v *Table) VisitImage(i *uefi.FlashImage) error {
-	return v.printRow(i, "Image", "", "", "")
-}
-
-// VisitFV applies a Table visitor to FirmwareVolume.
-func (v *Table) VisitFV(fv *uefi.FirmwareVolume) error {
-	return v.printRow(fv, "FV", fv.FileSystemGUID.String(), "", fv.Length)
-}
-
-// VisitFile applies a Table visitor to File.
-func (v *Table) VisitFile(f *uefi.File) error {
-	// TODO: make name part of the file node
-	return v.printRow(f, "File", f.Header.UUID.String(), f.Header.Type, f.Header.ExtendedSize)
-}
-
-// VisitSection applies a Table visitor to Section.
-func (v *Table) VisitSection(s *uefi.Section) error {
-	return v.printRow(s, "Sec", s.Name, s.Type, fmt.Sprintf("%d", s.Header.ExtendedSize))
-}
-
-// VisitIFD applies the Table visitor on a FlashDescriptor.
-func (v *Table) VisitIFD(fd *uefi.FlashDescriptor) error {
-	return v.printRow(fd, "IFD", "", "", "")
-}
-
-// VisitBIOSRegion applies the Table visitor on a BIOSRegion.
-func (v *Table) VisitBIOSRegion(br *uefi.BIOSRegion) error {
-	return v.printRow(br, "BIOS", "", "", "")
-}
-
-// VisitMERegion applies the Table visitor on a MERegion.
-func (v *Table) VisitMERegion(me *uefi.MERegion) error {
-	return v.printRow(me, "ME", "", "", "")
-}
-
-// VisitGBERegion applies the Table visitor on a GBERegion.
-func (v *Table) VisitGBERegion(gbe *uefi.GBERegion) error {
-	return v.printRow(gbe, "GBE", "", "", "")
-}
-
-// VisitPDRegion applies the Table visitor on a PDRegion.
-func (v *Table) VisitPDRegion(pd *uefi.PDRegion) error {
-	return v.printRow(pd, "PD", "", "", "")
 }
 
 func init() {


### PR DESCRIPTION
Most of the visitors only needed to implement a handful of the
functions. The remaining functions have some default behaviour.

This change simplifies creating new visitors because the default
behaviour can be placed in the default case.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>