### PR TITLE
travis: stop testing against go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 go:
   - "1.10"
-  - tip
 
 before_install:
   - go get -t -v ./...


### PR DESCRIPTION
It's not a good idea, go tip is always in motion and you get
false negatives.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>