### PR TITLE
Fix save visitor and fv assemble

### DIFF
--- a/pkg/visitors/assemble.go
+++ b/pkg/visitors/assemble.go
@@ -61,8 +61,9 @@ func (v *Assemble) Visit(f uefi.Firmware) error {
 
 		fileOffset := f.DataOffset
 		if f.DataOffset != fBufLen {
-			return fmt.Errorf("fv header buffer size mismatch with DataOffset! buflen was %#x, DataOffset was %#x",
-				fBufLen, f.DataOffset)
+			// remove all old file data
+			fBuf = fBuf[:f.DataOffset]
+			f.SetBuf(fBuf)
 		}
 
 		for _, file := range f.Files {

--- a/pkg/visitors/save.go
+++ b/pkg/visitors/save.go
@@ -25,7 +25,9 @@ func (v *Save) Run(f uefi.Firmware) error {
 func (v *Save) Visit(f uefi.Firmware) error {
 	a := &Assemble{}
 	// Assemble the binary to make sure the top level buffer is correct
-	f.Apply(a)
+	if err := f.Apply(a); err != nil {
+		return err
+	}
 	return ioutil.WriteFile(v.DirPath, f.Buf(), 0666)
 }
 


### PR DESCRIPTION
The save visitor wasn't reporting errors correctly.
The fv assemble incorrectly assumed there would only
be the FV head in the buffer.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>