### PR TITLE
add a cat command to visitor package

### DIFF
--- a/pkg/visitors/cat.go
+++ b/pkg/visitors/cat.go
@@ -1,0 +1,83 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"io"
+	"os"
+	"regexp"
+
+	"github.com/linuxboot/fiano/pkg/uefi"
+)
+
+// Cat concatenates all RAW data sections from a file into a single byte slice.
+type Cat struct {
+	// Input
+	Predicate func(f *uefi.File, name string) bool
+
+	// Output
+	io.Writer
+	Matches []*uefi.File
+}
+
+// Run wraps Visit and performs some setup and teardown tasks.
+func (v *Cat) Run(f uefi.Firmware) error {
+	// First run "find" to generate a list of matches to replace.
+	find := Find{
+		Predicate: v.Predicate,
+	}
+	if err := find.Run(f); err != nil {
+		return err
+	}
+
+	v.Matches = find.Matches
+	for _, m := range v.Matches {
+		if err := m.Apply(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Visit applies the Extract visitor to any Firmware type.
+func (v *Cat) Visit(f uefi.Firmware) error {
+	switch f := f.(type) {
+
+	case *uefi.File:
+		return f.ApplyChildren(v)
+
+	case *uefi.Section:
+		if f.Header.Type == uefi.SectionTypeRaw {
+			// TODO: figure out how to compute how many bytes
+			// to throw away. We tried once and gave up.
+			// UEFI ... what can you say.
+			if _, err := v.Write(f.Buf()[4:]); err != nil {
+				return err
+			}
+		}
+		return f.ApplyChildren(v)
+
+	default:
+		// Must be applied to a File to have any effect.
+		return nil
+	}
+}
+
+func init() {
+	RegisterCLI("cat", 1, func(args []string) (uefi.Visitor, error) {
+		searchRE, err := regexp.Compile(args[0])
+		if err != nil {
+			return nil, err
+		}
+
+		// Find all the matching files and cat the RAW sections into the Buf
+		return &Cat{
+			Predicate: func(f *uefi.File, name string) bool {
+				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.UUID.String())
+			},
+			Writer: os.Stdout,
+		}, nil
+	})
+}

--- a/pkg/visitors/cat_test.go
+++ b/pkg/visitors/cat_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/linuxboot/fiano/pkg/uefi"
+	"github.com/linuxboot/fiano/pkg/uuid"
+)
+
+var (
+	catGUID = uuid.MustParse("1B45CC0A-156A-428A-AF62-49864DA0E6E6")
+	catdat  = []byte{79, 218, 58, 155, 86, 174, 36, 76, 141, 234, 240, 59, 117, 88, 174, 80}
+)
+
+func TestCat(t *testing.T) {
+	f := parseImage(t)
+
+	// Apply the visitor.
+	var b bytes.Buffer
+	cat := &Cat{
+		Predicate: func(f *uefi.File, name string) bool {
+			m := f.Header.UUID == *catGUID
+			t.Logf("Check file UUID %v against %v: %v", f.Header.UUID.String(), *catGUID, m)
+			return m
+		},
+		Writer: &b,
+	}
+	if err := cat.Run(f); err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect one match.
+	if len(cat.Matches) != 1 {
+		t.Fatalf("got %d matches; expected 1", len(cat.Matches))
+	}
+
+	if !reflect.DeepEqual(b.Bytes(), catdat) {
+		t.Errorf("bytes.Buffer: want %v; got %v", catdat, b.Bytes())
+	}
+}


### PR DESCRIPTION
This is a lot like replace. It will cat all files which match a GUID to a byte slice.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>