### PR TITLE
Implement free space line for table visitor.

### DIFF
--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -99,7 +99,8 @@ type FirmwareVolume struct {
 	buf         []byte
 	FVOffset    uint64 // Byte offset from start of BIOS region.
 	ExtractPath string
-	Resizable   bool // Determines if this FV is resizable.
+	Resizable   bool   // Determines if this FV is resizable.
+	FreeSpace   uint64 `json:"-"`
 }
 
 // Buf returns the buffer.
@@ -229,6 +230,7 @@ func (fv *FirmwareVolume) InsertFile(alignedOffset uint64, fBuf []byte) error {
 	}
 	// Overwrite old data in the firmware volume.
 	fv.buf = append(fv.buf, fBuf...)
+	fv.FreeSpace = Align8(fv.Length - uint64(len(fv.buf)))
 	return nil
 }
 
@@ -319,6 +321,7 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 		}
 		if file == nil {
 			// We've reached free space. Terminate
+			fv.FreeSpace = fv.Length - offset
 			break
 		}
 		fv.Files = append(fv.Files, file)

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -66,7 +66,14 @@ func (v *Table) printRow(f uefi.Firmware, node, name, typez, size interface{}) e
 	fmt.Fprintf(v.W, "%s%v\t%v\t%v\t%v\n", indent(v.indent), node, name, typez, size)
 	v2 := *v
 	v2.indent++
-	return f.ApplyChildren(&v2)
+	if err := f.ApplyChildren(&v2); err != nil {
+		return err
+	}
+	if fv, ok := f.(*uefi.FirmwareVolume); ok {
+		// Print free space at the end of the volume
+		fmt.Fprintf(v.W, "%s%v\t%v\t%v\t%v\n", indent(v2.indent), "Volume Free Space", "", "", fv.FreeSpace)
+	}
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
This tells us how much free space is left at the end of the firmware volume

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>