### PR TITLE
pkg/uefi: fix to be more paranoid if a buffer is too short or a header malformed.

### DIFF
--- a/pkg/uefi/flash_test.go
+++ b/pkg/uefi/flash_test.go
@@ -64,3 +64,19 @@ func TestIsPCH(t *testing.T) {
 		}
 	}
 }
+
+// TestShort catches cases where the firmware header has bogus start and offset values.
+func TestShort(t *testing.T) {
+	t.Skip()
+	var tests = []struct {
+		buf []byte
+		out bool
+	}{
+		{emptySig, false},
+		{pchSig, true},
+	}
+	for _, test := range tests {
+		f, err := NewFlashImage(test.buf)
+		t.Logf("f %v err %v", f, err)
+	}
+}


### PR DESCRIPTION
I had a malformed image created by utk which was causing this:
rminnich@uroot:~/projects/NERF/equus$ utk new.rom table
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/linuxboot/fiano/pkg/uefi.NewFlashImage(0xc00009e000, 0x1a26000, 0x1a26200, 0x14, 0x0, 0x0)
	/home/rminnich/go/src/github.com/linuxboot/fiano/pkg/uefi/flash.go:249 +0xf99
github.com/linuxboot/fiano/pkg/uefi.Parse(0xc00009e000, 0x1a26000, 0x1a26200, 0x1a26000, 0x1a26200, 0x0, 0x0)
	/home/rminnich/go/src/github.com/linuxboot/fiano/pkg/uefi/uefi.go:133 +0xcc
main.main()
	/home/rminnich/go/src/github.com/linuxboot/fiano/cmds/utk/utk.go:109 +0x476

With this change we get this:

rminnich@uroot:~/projects/NERF/equus$ utk new.rom table
2018/09/13 19:52:49 27418624 byte buf is too short for end BIOS: need 33554432 bytes
rminnich@uroot:~/projects/NERF/equus$

The file new.rom was created by this:
utk test.rom remove '^Ip.*' save new.rom

Arguably this should also be caught by Validate, but if a programmer
makes a mistake and does not call Validate it's nice to have an error message.

I took the opportunity to change the code a bit so that there is a common
for loop over a [] of structs using a closure to isolate some of the operations.

Take a look and you'll see what I mean. I think overall it's probably better
as we can write the common checking code once, not 5 times.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>