### PR TITLE
Rename all instances of uuid to guid

### DIFF
--- a/pkg/guid/guid.go
+++ b/pkg/guid/guid.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package uuid implements the mixed-endian UUID as implemented by Microsoft.
-package uuid
+// Package guid implements the mixed-endian GUID as implemented by Microsoft.
+package guid
 
 import (
 	"encoding/hex"
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	// Size represents number of bytes in a UUID
+	// Size represents number of bytes in a GUID
 	Size = 16
-	// UExample is a example of a string UUID
+	// UExample is a example of a string GUID
 	UExample  = "01234567-89AB-CDEF-0123-456789ABCDEF"
 	textLen   = len(UExample)
 	strFormat = "%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X"
@@ -26,8 +26,8 @@ var (
 	fields = [...]int{4, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1}
 )
 
-// UUID represents a unique identifier.
-type UUID [Size]byte
+// GUID represents a unique identifier.
+type GUID [Size]byte
 
 func reverse(b []byte) {
 	for i := 0; i < len(b)/2; i++ {
@@ -36,22 +36,22 @@ func reverse(b []byte) {
 	}
 }
 
-// Parse parses a uuid string.
-func Parse(s string) (*UUID, error) {
+// Parse parses a guid string.
+func Parse(s string) (*GUID, error) {
 	// remove all hyphens to make it easier to parse.
 	stripped := strings.Replace(s, "-", "", -1)
 	decoded, err := hex.DecodeString(stripped)
 	if err != nil {
-		return nil, fmt.Errorf("uuid string not correct, need string of the format \n%v\n, got \n%v",
+		return nil, fmt.Errorf("guid string not correct, need string of the format \n%v\n, got \n%v",
 			UExample, s)
 	}
 
 	if len(decoded) != Size {
-		return nil, fmt.Errorf("uuid string has incorrect length, need string of the format \n%v\n, got \n%v",
+		return nil, fmt.Errorf("guid string has incorrect length, need string of the format \n%v\n, got \n%v",
 			UExample, s)
 	}
 
-	u := UUID{}
+	u := GUID{}
 	i := 0
 	copy(u[:], decoded[:])
 	// Correct for endianness.
@@ -62,16 +62,16 @@ func Parse(s string) (*UUID, error) {
 	return &u, nil
 }
 
-// MustParse parses a uuid string or panics.
-func MustParse(s string) *UUID {
-	uuid, err := Parse(s)
+// MustParse parses a guid string or panics.
+func MustParse(s string) *GUID {
+	guid, err := Parse(s)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return uuid
+	return guid
 }
 
-func (u UUID) String() string {
+func (u GUID) String() string {
 	// Not a pointer receiver so we don't have to manually copy.
 	i := 0
 	// reverse endianness.
@@ -89,19 +89,19 @@ func (u UUID) String() string {
 
 // MarshalJSON implements the marshaller interface.
 // This allows us to actually read and edit the json file
-func (u *UUID) MarshalJSON() ([]byte, error) {
-	return []byte(`{"UUID" : "` + u.String() + `"}`), nil
+func (u *GUID) MarshalJSON() ([]byte, error) {
+	return []byte(`{"GUID" : "` + u.String() + `"}`), nil
 }
 
 // UnmarshalJSON implements the unmarshaller interface.
 // This allows us to actually read and edit the json file
-func (u *UUID) UnmarshalJSON(b []byte) error {
+func (u *GUID) UnmarshalJSON(b []byte) error {
 	j := make(map[string]string)
 
 	if err := json.Unmarshal(b, &j); err != nil {
 		return err
 	}
-	g, err := Parse(j["UUID"])
+	g, err := Parse(j["GUID"])
 	if err != nil {
 		return err
 	}

--- a/pkg/guid/guid_test.go
+++ b/pkg/guid/guid_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package uuid
+package guid
 
 import (
 	"fmt"
@@ -10,39 +10,39 @@ import (
 )
 
 var (
-	// UUID examples
-	exampleUUID UUID = [16]byte{0x67, 0x45, 0x23, 0x01, 0xAB, 0x89, 0xEF, 0xCD,
+	// GUID examples
+	exampleGUID GUID = [16]byte{0x67, 0x45, 0x23, 0x01, 0xAB, 0x89, 0xEF, 0xCD,
 		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
-	// UUID string examples
-	exampleUUIDString   = "01234567-89AB-CDEF-0123-456789ABCDEF"
-	shortUUIDString     = "0123456789ABCDEF0123456789ABCDEF"
-	badUUIDStringLength = "01234567"
+	// GUID string examples
+	exampleGUIDString   = "01234567-89AB-CDEF-0123-456789ABCDEF"
+	shortGUIDString     = "0123456789ABCDEF0123456789ABCDEF"
+	badGUIDStringLength = "01234567"
 	badHex              = "GHGHGHGHGHGHGH"
 
-	// UUID JSON examples
-	exampleJSON       = `{"UUID" : "` + exampleUUIDString + `"}`
-	exampleJSONBadHex = `{"UUID" : "` + badHex + `"}`
-	exampleJSONBadKey = `{"UU" : "` + exampleUUIDString + `"}`
+	// GUID JSON examples
+	exampleJSON       = `{"GUID" : "` + exampleGUIDString + `"}`
+	exampleJSONBadHex = `{"GUID" : "` + badHex + `"}`
+	exampleJSONBadKey = `{"UU" : "` + exampleGUIDString + `"}`
 )
 
 func TestParse(t *testing.T) {
 	var tests = []struct {
 		s   string
-		u   *UUID
+		u   *GUID
 		msg string
 	}{
-		{exampleUUIDString, &exampleUUID, ""},
-		{shortUUIDString, &exampleUUID, ""},
-		{badUUIDStringLength, nil, fmt.Sprintf("uuid string has incorrect length, need string of the format \n%v\n, got \n%v",
-			UExample, badUUIDStringLength)},
-		{badHex, nil, fmt.Sprintf("uuid string not correct, need string of the format \n%v\n, got \n%v",
+		{exampleGUIDString, &exampleGUID, ""},
+		{shortGUIDString, &exampleGUID, ""},
+		{badGUIDStringLength, nil, fmt.Sprintf("guid string has incorrect length, need string of the format \n%v\n, got \n%v",
+			UExample, badGUIDStringLength)},
+		{badHex, nil, fmt.Sprintf("guid string not correct, need string of the format \n%v\n, got \n%v",
 			UExample, badHex)},
 	}
 	for _, test := range tests {
 		u, err := Parse(test.s)
 		if u == nil {
 			if test.u != nil {
-				t.Errorf("UUID was expected: %v, got nil", test.u)
+				t.Errorf("GUID was expected: %v, got nil", test.u)
 			}
 			if err == nil {
 				t.Errorf("Error was not returned, expected %v", test.msg)
@@ -50,7 +50,7 @@ func TestParse(t *testing.T) {
 				t.Errorf("Mismatched Error returned, expected \n%v\n got \n%v\n", test.msg, err.Error())
 			}
 		} else if *u != *test.u {
-			t.Errorf("UUID was parsed incorrectly, expected %v\n, got %v\n, string was %v", test.u, u, test.s)
+			t.Errorf("GUID was parsed incorrectly, expected %v\n, got %v\n, string was %v", test.u, u, test.s)
 		}
 	}
 }
@@ -58,9 +58,9 @@ func TestParse(t *testing.T) {
 func TestMarshal(t *testing.T) {
 	var tests = []struct {
 		j string
-		u *UUID
+		u *GUID
 	}{
-		{exampleJSON, &exampleUUID},
+		{exampleJSON, &exampleGUID},
 	}
 	for _, test := range tests {
 		j, err := test.u.MarshalJSON()
@@ -76,17 +76,17 @@ func TestMarshal(t *testing.T) {
 func TestUnmarshal(t *testing.T) {
 	var tests = []struct {
 		j   string
-		u   *UUID
+		u   *GUID
 		msg string
 	}{
-		{exampleJSON, &exampleUUID, ""},
-		{exampleJSONBadHex, nil, fmt.Sprintf("uuid string not correct, need string of the format \n%v\n, got \n%v",
+		{exampleJSON, &exampleGUID, ""},
+		{exampleJSONBadHex, nil, fmt.Sprintf("guid string not correct, need string of the format \n%v\n, got \n%v",
 			UExample, badHex)},
-		{exampleJSONBadKey, nil, fmt.Sprintf("uuid string has incorrect length, need string of the format \n%v\n, got \n%v",
+		{exampleJSONBadKey, nil, fmt.Sprintf("guid string has incorrect length, need string of the format \n%v\n, got \n%v",
 			UExample, "")},
 	}
 	for _, test := range tests {
-		var g UUID
+		var g GUID
 		err := g.UnmarshalJSON([]byte(test.j))
 		if test.msg == "" && err != nil {
 			t.Errorf("No error was expected, got %v", err)
@@ -98,7 +98,7 @@ func TestUnmarshal(t *testing.T) {
 			t.Errorf("Got Error msg %v, was expecting %v", err.Error(), test.msg)
 		}
 		if test.u != nil && *test.u != g {
-			t.Errorf("UUIDs are not equal. Expected:\n%v\ngot:\n%v", test.u, g)
+			t.Errorf("GUIDs are not equal. Expected:\n%v\ngot:\n%v", test.u, g)
 		}
 	}
 }

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/linuxboot/fiano/pkg/uuid"
+	"github.com/linuxboot/fiano/pkg/guid"
 )
 
 // FirmwareVolume constants
@@ -22,19 +22,19 @@ const (
 
 // Valid FV GUIDs
 var (
-	FFS1      = uuid.MustParse("7a9354d9-0468-444a-81ce-0bf617d890df")
-	FFS2      = uuid.MustParse("8c8ce578-8a3d-4f1c-9935-896185c32dd3")
-	FFS3      = uuid.MustParse("5473c07a-3dcb-4dca-bd6f-1e9689e7349a")
-	EVSA      = uuid.MustParse("fff12b8d-7696-4c8b-a985-2747075b4f50")
-	NVAR      = uuid.MustParse("cef5b9a3-476d-497f-9fdc-e98143e0422c")
-	EVSA2     = uuid.MustParse("00504624-8a59-4eeb-bd0f-6b36e96128e0")
-	AppleBoot = uuid.MustParse("04adeead-61ff-4d31-b6ba-64f8bf901f5a")
-	PFH1      = uuid.MustParse("16b45da2-7d70-4aea-a58d-760e9ecb841d")
-	PFH2      = uuid.MustParse("e360bdba-c3ce-46be-8f37-b231e5cb9f35")
+	FFS1      = guid.MustParse("7a9354d9-0468-444a-81ce-0bf617d890df")
+	FFS2      = guid.MustParse("8c8ce578-8a3d-4f1c-9935-896185c32dd3")
+	FFS3      = guid.MustParse("5473c07a-3dcb-4dca-bd6f-1e9689e7349a")
+	EVSA      = guid.MustParse("fff12b8d-7696-4c8b-a985-2747075b4f50")
+	NVAR      = guid.MustParse("cef5b9a3-476d-497f-9fdc-e98143e0422c")
+	EVSA2     = guid.MustParse("00504624-8a59-4eeb-bd0f-6b36e96128e0")
+	AppleBoot = guid.MustParse("04adeead-61ff-4d31-b6ba-64f8bf901f5a")
+	PFH1      = guid.MustParse("16b45da2-7d70-4aea-a58d-760e9ecb841d")
+	PFH2      = guid.MustParse("e360bdba-c3ce-46be-8f37-b231e5cb9f35")
 )
 
 // FVGUIDs holds common FV type names
-var FVGUIDs = map[uuid.UUID]string{
+var FVGUIDs = map[guid.GUID]string{
 	*FFS1:      "FFS1",
 	*FFS2:      "FFS2",
 	*FFS3:      "FFS3",
@@ -48,7 +48,7 @@ var FVGUIDs = map[uuid.UUID]string{
 
 // These are the FVs we actually try to parse beyond the header
 // We don't parse anything except FFS2 and FFS3
-var supportedFVs = map[uuid.UUID]bool{
+var supportedFVs = map[guid.GUID]bool{
 	*FFS2: true,
 	*FFS3: true,
 }
@@ -63,7 +63,7 @@ type Block struct {
 // header
 type FirmwareVolumeFixedHeader struct {
 	_               [16]uint8
-	FileSystemGUID  uuid.UUID
+	FileSystemGUID  guid.GUID
 	Length          uint64
 	Signature       uint32
 	Attributes      uint32 // UEFI PI spec volume 3.2.1 EFI_FIRMWARE_VOLUME_HEADER
@@ -78,7 +78,7 @@ type FirmwareVolumeFixedHeader struct {
 // FirmwareVolumeExtHeader contains the fields of an extended firmware volume
 // header
 type FirmwareVolumeExtHeader struct {
-	FVName        uuid.UUID
+	FVName        guid.GUID
 	ExtHeaderSize uint32
 }
 

--- a/pkg/uefi/section.go
+++ b/pkg/uefi/section.go
@@ -13,9 +13,9 @@ import (
 	"log"
 	"unsafe"
 
+	"github.com/linuxboot/fiano/pkg/guid"
 	"github.com/linuxboot/fiano/pkg/lzma"
 	"github.com/linuxboot/fiano/pkg/unicode"
-	"github.com/linuxboot/fiano/pkg/uuid"
 )
 
 const (
@@ -85,8 +85,8 @@ const (
 
 // Well-known GUIDs.
 var (
-	LZMAGUID    = *uuid.MustParse("EE4E5898-3914-4259-9D6E-DC7BD79403CF")
-	LZMAX86GUID = *uuid.MustParse("D42AE6BD-1352-4BFB-909A-CA72A6EAE889")
+	LZMAGUID    = *guid.MustParse("EE4E5898-3914-4259-9D6E-DC7BD79403CF")
+	LZMAX86GUID = *guid.MustParse("D42AE6BD-1352-4BFB-909A-CA72A6EAE889")
 )
 
 // SectionHeader represents an EFI_COMMON_SECTION_HEADER as specified in
@@ -106,7 +106,7 @@ type SectionExtHeader struct {
 // SectionGUIDDefinedHeader contains the fields for a EFI_SECTION_GUID_DEFINED
 // encapsulated section header.
 type SectionGUIDDefinedHeader struct {
-	GUID       uuid.UUID
+	GUID       guid.GUID
 	DataOffset uint16
 	Attributes uint16
 }
@@ -179,7 +179,7 @@ var DepExOpCodes = map[byte]DepExOpCode{
 // DepExOp contains one operation for the dependency expression.
 type DepExOp struct {
 	OpCode DepExOpCode
-	GUID   *uuid.UUID `json:",omitempty"`
+	GUID   *guid.GUID `json:",omitempty"`
 }
 
 // Section represents a Firmware File Section
@@ -387,7 +387,7 @@ func parseDepEx(b []byte) ([]DepExOp, error) {
 		if opCodeStr, ok := DepExOpCodes[opCodeByte]; ok {
 			op := DepExOp{OpCode: opCodeStr}
 			if opCodeStr == "BEFORE" || opCodeStr == "AFTER" || opCodeStr == "PUSH" {
-				op.GUID = &uuid.UUID{}
+				op.GUID = &guid.GUID{}
 				if err := binary.Read(r, binary.LittleEndian, op.GUID); err != nil {
 					return nil, fmt.Errorf("invalid DEPEX, could not read GUID: %v", err)
 				}

--- a/pkg/uefi/section_test.go
+++ b/pkg/uefi/section_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/linuxboot/fiano/pkg/uuid"
+	"github.com/linuxboot/fiano/pkg/guid"
 )
 
 var (
@@ -153,26 +153,26 @@ func TestParseDepEx(t *testing.T) {
 				0x08, // END
 			},
 			out: []DepExOp{
-				{OpCode: "PUSH", GUID: uuid.MustParse("665E3FF6-46CC-11D4-9A38-0090273FC14D")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("26BACCB1-6F42-11D4-BCE7-0080C73C8881")},
+				{OpCode: "PUSH", GUID: guid.MustParse("665E3FF6-46CC-11D4-9A38-0090273FC14D")},
+				{OpCode: "PUSH", GUID: guid.MustParse("26BACCB1-6F42-11D4-BCE7-0080C73C8881")},
 				{OpCode: "AND"},
-				{OpCode: "PUSH", GUID: uuid.MustParse("26BACCB2-6F42-11D4-BCE7-0080C73C8881")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("1DA97072-BDDC-4B30-99F1-72A0B56FFF2A")},
-				{OpCode: "AND"},
-				{OpCode: "AND"},
-				{OpCode: "PUSH", GUID: uuid.MustParse("27CFAC87-46CC-11D4-9A38-0090273FC14D")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("27CFAC88-46CC-11D4-9A38-0090273FC14D")},
-				{OpCode: "AND"},
-				{OpCode: "PUSH", GUID: uuid.MustParse("96D08253-8483-11D4-BCF1-0080C73C8881")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("A46423E3-4617-49F1-B9FF-D1BFA9115839")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("26BACCB3-6F42-11D4-BCE7-0080C73C8881")},
-				{OpCode: "AND"},
-				{OpCode: "PUSH", GUID: uuid.MustParse("1E5668E2-8481-11D4-BCF1-0080C73C8881")},
-				{OpCode: "PUSH", GUID: uuid.MustParse("6441F818-6362-4E44-B570-7DBA31DD2453")},
+				{OpCode: "PUSH", GUID: guid.MustParse("26BACCB2-6F42-11D4-BCE7-0080C73C8881")},
+				{OpCode: "PUSH", GUID: guid.MustParse("1DA97072-BDDC-4B30-99F1-72A0B56FFF2A")},
 				{OpCode: "AND"},
 				{OpCode: "AND"},
+				{OpCode: "PUSH", GUID: guid.MustParse("27CFAC87-46CC-11D4-9A38-0090273FC14D")},
+				{OpCode: "PUSH", GUID: guid.MustParse("27CFAC88-46CC-11D4-9A38-0090273FC14D")},
 				{OpCode: "AND"},
-				{OpCode: "PUSH", GUID: uuid.MustParse("665E3FF5-46CC-11D4-9A38-0090273FC14D")},
+				{OpCode: "PUSH", GUID: guid.MustParse("96D08253-8483-11D4-BCF1-0080C73C8881")},
+				{OpCode: "PUSH", GUID: guid.MustParse("A46423E3-4617-49F1-B9FF-D1BFA9115839")},
+				{OpCode: "PUSH", GUID: guid.MustParse("26BACCB3-6F42-11D4-BCE7-0080C73C8881")},
+				{OpCode: "AND"},
+				{OpCode: "PUSH", GUID: guid.MustParse("1E5668E2-8481-11D4-BCF1-0080C73C8881")},
+				{OpCode: "PUSH", GUID: guid.MustParse("6441F818-6362-4E44-B570-7DBA31DD2453")},
+				{OpCode: "AND"},
+				{OpCode: "AND"},
+				{OpCode: "AND"},
+				{OpCode: "PUSH", GUID: guid.MustParse("665E3FF5-46CC-11D4-9A38-0090273FC14D")},
 				{OpCode: "AND"},
 				{OpCode: "END"}},
 		},

--- a/pkg/visitors/assemble.go
+++ b/pkg/visitors/assemble.go
@@ -76,7 +76,7 @@ func (v *Assemble) Visit(f uefi.Firmware) error {
 			fileBuf := file.Buf()
 			fileLen := uint64(len(fileBuf))
 			if fileLen == 0 {
-				log.Fatal(file.Header.UUID)
+				log.Fatal(file.Header.GUID)
 			}
 
 			// Pad to the 8 byte alignments.
@@ -101,13 +101,13 @@ func (v *Assemble) Visit(f uefi.Firmware) error {
 						return err
 					}
 					if err = f.InsertFile(alignedOffset, pfile.Buf()); err != nil {
-						return fmt.Errorf("File %s: %v", pfile.Header.UUID, err)
+						return fmt.Errorf("File %s: %v", pfile.Header.GUID, err)
 					}
 				}
 				alignedOffset = newOffset
 			}
 			if err = f.InsertFile(alignedOffset, fileBuf); err != nil {
-				return fmt.Errorf("File %s: %v", file.Header.UUID, err)
+				return fmt.Errorf("File %s: %v", file.Header.GUID, err)
 			}
 			fileOffset = alignedOffset + fileLen
 		}

--- a/pkg/visitors/cat.go
+++ b/pkg/visitors/cat.go
@@ -75,7 +75,7 @@ func init() {
 		// Find all the matching files and cat the RAW sections into the Buf
 		return &Cat{
 			Predicate: func(f *uefi.File, name string) bool {
-				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.UUID.String())
+				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.GUID.String())
 			},
 			Writer: os.Stdout,
 		}, nil

--- a/pkg/visitors/cat_test.go
+++ b/pkg/visitors/cat_test.go
@@ -9,12 +9,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/linuxboot/fiano/pkg/guid"
 	"github.com/linuxboot/fiano/pkg/uefi"
-	"github.com/linuxboot/fiano/pkg/uuid"
 )
 
 var (
-	catGUID = uuid.MustParse("1B45CC0A-156A-428A-AF62-49864DA0E6E6")
+	catGUID = guid.MustParse("1B45CC0A-156A-428A-AF62-49864DA0E6E6")
 	catdat  = []byte{79, 218, 58, 155, 86, 174, 36, 76, 141, 234, 240, 59, 117, 88, 174, 80}
 )
 
@@ -25,8 +25,8 @@ func TestCat(t *testing.T) {
 	var b bytes.Buffer
 	cat := &Cat{
 		Predicate: func(f *uefi.File, name string) bool {
-			m := f.Header.UUID == *catGUID
-			t.Logf("Check file UUID %v against %v: %v", f.Header.UUID.String(), *catGUID, m)
+			m := f.Header.GUID == *catGUID
+			t.Logf("Check file GUID %v against %v: %v", f.Header.GUID.String(), *catGUID, m)
 			return m
 		},
 		Writer: &b,

--- a/pkg/visitors/extract.go
+++ b/pkg/visitors/extract.go
@@ -91,12 +91,12 @@ func (v *Extract) Visit(f uefi.Firmware) error {
 
 	case *uefi.File:
 		// For files we use the GUID as the folder name.
-		v2.DirPath = filepath.Join(v.DirPath, f.Header.UUID.String())
+		v2.DirPath = filepath.Join(v.DirPath, f.Header.GUID.String())
 		// Crappy hack to make unique ids unique
 		v2.DirPath = filepath.Join(v2.DirPath, fmt.Sprint(*v.Index))
 		*v.Index++
 		if len(f.Sections) == 0 {
-			f.ExtractPath, err = uefi.ExtractBinary(f.Buf(), v2.DirPath, fmt.Sprintf("%v.ffs", f.Header.UUID))
+			f.ExtractPath, err = uefi.ExtractBinary(f.Buf(), v2.DirPath, fmt.Sprintf("%v.ffs", f.Header.GUID))
 		}
 
 	case *uefi.Section:

--- a/pkg/visitors/find.go
+++ b/pkg/visitors/find.go
@@ -66,7 +66,7 @@ func init() {
 		}
 		return &Find{
 			Predicate: func(f *uefi.File, name string) bool {
-				if searchRE.MatchString(name) || searchRE.MatchString(f.Header.UUID.String()) {
+				if searchRE.MatchString(name) || searchRE.MatchString(f.Header.GUID.String()) {
 					b, err := json.MarshalIndent(f, "", "\t")
 					if err != nil {
 						log.Fatal(err)

--- a/pkg/visitors/helpers_test.go
+++ b/pkg/visitors/helpers_test.go
@@ -8,12 +8,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/linuxboot/fiano/pkg/guid"
 	"github.com/linuxboot/fiano/pkg/uefi"
-	"github.com/linuxboot/fiano/pkg/uuid"
 )
 
 // This GUID exists somewhere in the OVMF image.
-var testGUID = uuid.MustParse("DF1CCEF6-F301-4A63-9661-FC6030DCC880")
+var testGUID = guid.MustParse("DF1CCEF6-F301-4A63-9661-FC6030DCC880")
 
 func parseImage(t *testing.T) uefi.Firmware {
 	image, err := ioutil.ReadFile("../../integration/roms/OVMF.rom")
@@ -27,10 +27,10 @@ func parseImage(t *testing.T) uefi.Firmware {
 	return parsedRoot
 }
 
-func find(t *testing.T, f uefi.Firmware, guid *uuid.UUID) []*uefi.File {
+func find(t *testing.T, f uefi.Firmware, guid *guid.GUID) []*uefi.File {
 	find := &Find{
 		Predicate: func(f *uefi.File, name string) bool {
-			return f.Header.UUID == *guid
+			return f.Header.GUID == *guid
 		},
 	}
 	if err := find.Run(f); err != nil {

--- a/pkg/visitors/remove.go
+++ b/pkg/visitors/remove.go
@@ -67,7 +67,7 @@ func init() {
 		}
 		return &Remove{
 			Predicate: func(f *uefi.File, name string) bool {
-				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.UUID.String())
+				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.GUID.String())
 			},
 		}, nil
 	})

--- a/pkg/visitors/remove_test.go
+++ b/pkg/visitors/remove_test.go
@@ -16,7 +16,7 @@ func TestRemove(t *testing.T) {
 	// Apply the visitor.
 	remove := &Remove{
 		Predicate: func(f *uefi.File, name string) bool {
-			return f.Header.UUID == *testGUID
+			return f.Header.GUID == *testGUID
 		},
 	}
 	if err := remove.Run(f); err != nil {

--- a/pkg/visitors/replacepe32.go
+++ b/pkg/visitors/replacepe32.go
@@ -78,7 +78,7 @@ func init() {
 		// Find all the matching files and replace their inner PE32s.
 		return &ReplacePE32{
 			Predicate: func(f *uefi.File, name string) bool {
-				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.UUID.String())
+				return searchRE.MatchString(name) || searchRE.MatchString(f.Header.GUID.String())
 			},
 			NewPE32: newPE32,
 		}, nil

--- a/pkg/visitors/replacepe32_test.go
+++ b/pkg/visitors/replacepe32_test.go
@@ -17,7 +17,7 @@ func TestReplacePE32(t *testing.T) {
 	// Apply the visitor.
 	replace := &ReplacePE32{
 		Predicate: func(f *uefi.File, name string) bool {
-			return f.Header.UUID == *testGUID
+			return f.Header.GUID == *testGUID
 		},
 		NewPE32: []byte("banana"),
 	}

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -33,7 +33,7 @@ func (v *Table) Visit(f uefi.Firmware) error {
 		return v.printRow(f, "FV", f.FileSystemGUID.String(), "")
 	case *uefi.File:
 		// TODO: make name part of the file node
-		return v.printRow(f, "File", f.Header.UUID.String(), f.Header.Type)
+		return v.printRow(f, "File", f.Header.GUID.String(), f.Header.Type)
 	case *uefi.Section:
 		return v.printRow(f, "Sec", f.Name, f.Type)
 	case *uefi.FlashDescriptor:

--- a/pkg/visitors/validate.go
+++ b/pkg/visitors/validate.go
@@ -143,35 +143,35 @@ func (v *Validate) Visit(f uefi.Firmware) error {
 		if fh.Size == blankSize {
 			if buflen < uefi.FileHeaderExtMinLength {
 				v.Errors = append(v.Errors, fmt.Errorf("file %v length too small!, buffer is only %#x bytes long for extended header",
-					fh.UUID, buflen))
+					fh.GUID, buflen))
 				break
 			}
 			if !fh.Attributes.IsLarge() {
 				v.Errors = append(v.Errors, fmt.Errorf("file %v using extended header, but large attribute is not set",
-					fh.UUID))
+					fh.GUID))
 				break
 			}
 		} else if uefi.Read3Size(f.Header.Size) != fh.ExtendedSize {
 			v.Errors = append(v.Errors, fmt.Errorf("file %v size not copied into extendedsize",
-				fh.UUID))
+				fh.GUID))
 			break
 		}
 		if buflen != fh.ExtendedSize {
 			v.Errors = append(v.Errors, fmt.Errorf("file %v size mismatch! Size is %#x, buf length is %#x",
-				fh.UUID, fh.ExtendedSize, buflen))
+				fh.GUID, fh.ExtendedSize, buflen))
 			break
 		}
 
 		// Header Checksums
 		if sum := f.ChecksumHeader(); sum != 0 {
 			v.Errors = append(v.Errors, fmt.Errorf("file %v header checksum failure! sum was %v",
-				fh.UUID, sum))
+				fh.GUID, sum))
 		}
 
 		// Body Checksum
 		if !fh.Attributes.HasChecksum() && fh.Checksum.File != uefi.EmptyBodyChecksum {
 			v.Errors = append(v.Errors, fmt.Errorf("file %v body checksum failure! Attribute was not set, but sum was %v instead of %v",
-				fh.UUID, fh.Checksum.File, uefi.EmptyBodyChecksum))
+				fh.GUID, fh.Checksum.File, uefi.EmptyBodyChecksum))
 		} else if fh.Attributes.HasChecksum() {
 			headerSize := uefi.FileHeaderMinLength
 			if fh.Attributes.IsLarge() {
@@ -179,7 +179,7 @@ func (v *Validate) Visit(f uefi.Firmware) error {
 			}
 			if sum := uefi.Checksum8(f.Buf()[headerSize:]); sum != 0 { // TODO: use the Payload function which does not exist yet
 				v.Errors = append(v.Errors, fmt.Errorf("file %v body checksum failure! sum was %v",
-					fh.UUID, sum))
+					fh.GUID, sum))
 			}
 		}
 


### PR DESCRIPTION
The UEFI spec refers to them as GUIDs.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>