### PR TITLE
Insert Visitor

### DIFF
--- a/pkg/visitors/find.go
+++ b/pkg/visitors/find.go
@@ -111,6 +111,25 @@ func FindFilePredicate(r string) (func(f uefi.Firmware) bool, error) {
 	}, nil
 }
 
+// FindFileFVPredicate is a generic predicate for searching FVs, files and UI sections.
+func FindFileFVPredicate(r string) (func(f uefi.Firmware) bool, error) {
+	searchRE, err := regexp.Compile(r)
+	if err != nil {
+		return nil, err
+	}
+	return func(f uefi.Firmware) bool {
+		switch f := f.(type) {
+		case *uefi.FirmwareVolume:
+			return searchRE.MatchString(f.FVName.String())
+		case *uefi.File:
+			return searchRE.MatchString(f.Header.GUID.String())
+		case *uefi.Section:
+			return searchRE.MatchString(f.Name)
+		}
+		return false
+	}, nil
+}
+
 func init() {
 	RegisterCLI("find", "find a file by GUID or Name", 1, func(args []string) (uefi.Visitor, error) {
 		pred, err := FindFilePredicate(args[0])

--- a/pkg/visitors/insert.go
+++ b/pkg/visitors/insert.go
@@ -1,0 +1,162 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/linuxboot/fiano/pkg/uefi"
+)
+
+// InsertType defines the insert type operation that is requested
+type InsertType int
+
+// Insert Types
+const (
+	// These first two specify a firmware volume.
+
+	// InsertFront inserts a file at the beginning of the firmware volume,
+	// which is specified by 1) FVname GUID, or (File GUID/File name) of a file
+	// inside that FV.
+	InsertFront InsertType = iota
+	// InsertEnd inserts a file at the end of the specified firmware volume.
+	InsertEnd
+
+	// These two specify a File to insert before or after
+	// InsertAfter inserts after the specified file,
+	// which is specified by a File GUID or File name.
+	InsertAfter
+	// InsertBefore inserts before the specified file.
+	InsertBefore
+	// TODO: Add InsertIn
+)
+
+var insertTypeNames = map[InsertType]string{
+	InsertFront:  "insert_front",
+	InsertEnd:    "insert_end",
+	InsertAfter:  "insert_after",
+	InsertBefore: "insert_before",
+}
+
+// String creates a string representation for the insert type.
+func (i InsertType) String() string {
+	if t, ok := insertTypeNames[i]; ok {
+		return t
+	}
+	return "UNKNOWN"
+}
+
+// Insert inserts a firmware file into an FV
+type Insert struct {
+	// Input
+	Predicate func(f uefi.Firmware) bool
+	NewFile   *uefi.File
+	InsertType
+
+	// Matched File
+	FileMatch uefi.Firmware
+}
+
+// Run wraps Visit and performs some setup and teardown tasks.
+func (v *Insert) Run(f uefi.Firmware) error {
+	// First run "find" to generate a position to insert into.
+	find := Find{
+		Predicate: v.Predicate,
+	}
+	if err := find.Run(f); err != nil {
+		return err
+	}
+
+	if numMatch := len(find.Matches); numMatch > 1 {
+		return fmt.Errorf("more than one match, only one match allowed! got %v", find.Matches)
+	} else if numMatch == 0 {
+		return errors.New("no matches found")
+	}
+
+	// Find should only match a file or a firmware volume. If it's an FV, we can
+	// edit the FV directly.
+	if fvMatch, ok := find.Matches[0].(*uefi.FirmwareVolume); ok {
+		switch v.InsertType {
+		case InsertFront:
+			fvMatch.Files = append([]*uefi.File{v.NewFile}, fvMatch.Files...)
+		case InsertEnd:
+			fvMatch.Files = append(fvMatch.Files, v.NewFile)
+		default:
+			return fmt.Errorf("matched FV but insert operation was %s, which only matches Files",
+				v.InsertType.String())
+		}
+		return nil
+	}
+	var ok bool
+	if v.FileMatch, ok = find.Matches[0].(*uefi.File); !ok {
+		return fmt.Errorf("match was not a file or a firmware volume: got %T, unable to insert", find.Matches[0])
+	}
+	// Match is a file, apply visitor.
+	return f.Apply(v)
+}
+
+// Visit applies the Insert visitor to any Firmware type.
+func (v *Insert) Visit(f uefi.Firmware) error {
+	switch f := f.(type) {
+	case *uefi.FirmwareVolume:
+		for i := 0; i < len(f.Files); i++ {
+			if f.Files[i] == v.FileMatch {
+				switch v.InsertType {
+				case InsertFront:
+					f.Files = append([]*uefi.File{v.NewFile}, f.Files...)
+				case InsertEnd:
+					f.Files = append(f.Files, v.NewFile)
+				case InsertAfter:
+					f.Files = append(f.Files[:i+1], append([]*uefi.File{v.NewFile}, f.Files[i+1:]...)...)
+				case InsertBefore:
+					f.Files = append(f.Files[:i], append([]*uefi.File{v.NewFile}, f.Files[i:]...)...)
+				}
+				return nil
+			}
+		}
+	}
+
+	return f.ApplyChildren(v)
+}
+
+func genInsertCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
+	return func(args []string) (uefi.Visitor, error) {
+		pred, err := FindFileFVPredicate(args[0])
+		if err != nil {
+			return nil, err
+		}
+
+		filename := args[1]
+		newFileBuf, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		// Parse the file.
+		file, err := uefi.NewFile(newFileBuf)
+		if err != nil {
+			return nil, err
+		}
+
+		// Insert File.
+		return &Insert{
+			Predicate:  pred,
+			NewFile:    file,
+			InsertType: iType,
+		}, nil
+	}
+}
+
+func init() {
+	RegisterCLI(insertTypeNames[InsertFront],
+		"insert a file at the beginning of a firmware volume", 2, genInsertCLI(InsertFront))
+	RegisterCLI(insertTypeNames[InsertEnd],
+		"insert a file at the end of a firmware volume", 2, genInsertCLI(InsertEnd))
+	RegisterCLI(insertTypeNames[InsertAfter],
+		"insert a file after another file", 2, genInsertCLI(InsertAfter))
+	RegisterCLI(insertTypeNames[InsertBefore],
+		"insert a file before another file", 2, genInsertCLI(InsertBefore))
+}

--- a/pkg/visitors/insert_test.go
+++ b/pkg/visitors/insert_test.go
@@ -1,0 +1,121 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/uefi"
+)
+
+func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUID guid.GUID) (*Insert, error) {
+	file, err := ioutil.ReadFile("../../integration/roms/testfile.ffs")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ffs, err := uefi.NewFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Apply the visitor.
+	insert := &Insert{
+		Predicate:  FindFileGUIDPredicate(testGUID),
+		NewFile:    ffs,
+		InsertType: insertType,
+	}
+
+	return insert, insert.Run(f)
+}
+
+func TestInsert(t *testing.T) {
+	var tests = []struct {
+		name string
+		InsertType
+	}{
+		{InsertFront.String(), InsertFront},
+		{InsertEnd.String(), InsertEnd},
+		{InsertAfter.String(), InsertAfter},
+		{InsertBefore.String(), InsertBefore},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := parseImage(t)
+
+			_, err := testRunInsert(t, f, test.InsertType, *testGUID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Now check that f has two copies of testGUID (There was one, we inserted another).
+			// TODO: Check for position in the future to make sure we actually insert where we want to.
+			find := &Find{
+				Predicate: FindFileGUIDPredicate(*testGUID),
+			}
+			if err = find.Run(f); err != nil {
+				t.Fatal(err)
+			}
+			if len(find.Matches) != 2 {
+				t.Errorf("Incorrect number of matches after insertion! expected 2, got %v", len(find.Matches))
+			}
+		})
+	}
+}
+
+func TestDoubleFindInsert(t *testing.T) {
+	var tests = []struct {
+		name string
+		InsertType
+	}{
+		{"insert_after double result", InsertAfter},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := parseImage(t)
+
+			insert, err := testRunInsert(t, f, test.InsertType, *testGUID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Run it again, it should fail
+			if err = insert.Run(f); err == nil {
+				t.Fatal("Expected error, got nil.")
+			}
+			if !strings.HasPrefix(err.Error(), "more than one match, only one match allowed! got ") {
+				t.Errorf("Mismatched error, got %v.", err.Error())
+			}
+
+		})
+	}
+}
+
+func TestNoFindInsert(t *testing.T) {
+	var tests = []struct {
+		name string
+		InsertType
+	}{
+		{"insert_after no file", InsertAfter},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := parseImage(t)
+
+			_, err := testRunInsert(t, f, test.InsertType,
+				*guid.MustParse("DECAFBAD-0000-0000-0000-000000000000"))
+			// It should fail due to no such file
+			if err == nil {
+				t.Fatal("Expected error, got nil.")
+			}
+			if err.Error() != "no matches found" {
+				t.Errorf("Mismatched error, got %v.", err.Error())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This adds 5 command line operations: insert_front, insert_end,
insert_in, insert_after, and insert_before

insert_front <FV GUID, File GUID, File Name> file.ffs:
Inserts at the front of the specified FV

insert_end <FV GUID, File GUID, File Name> file.ffs:
Inserts at the end of the specified FV

insert_in <FV GUID, File GUID, File Name> file.ffs:
Inserts somewhere in the specified FV

insert_after <File GUID, File Name> file.ffs:
Inserts after the specified file

insert_before <File GUID, File Name> file.ffs:
Inserts before the specified file

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>