### PR TITLE
Copy buffers rather than slicing

### DIFF
--- a/pkg/uefi/biosregion.go
+++ b/pkg/uefi/biosregion.go
@@ -80,9 +80,14 @@ func (br *BIOSRegion) FlashRegion() (fr *FlashRegion) {
 // object, if a valid one is passed, or an error. It also points to the
 // Region struct uncovered in the ifd.
 func NewBIOSRegion(buf []byte, r *FlashRegion, _ FlashRegionType) (Region, error) {
-	br := BIOSRegion{buf: buf, flashRegion: r, Length: uint64(len(buf)),
+	br := BIOSRegion{flashRegion: r, Length: uint64(len(buf)),
 		RegionType: RegionTypeBIOS}
 	var absOffset uint64
+
+	// Copy the buffer
+	br.buf = make([]byte, len(buf))
+	copy(br.buf, buf)
+
 	for {
 		offset := FindFirmwareVolumeOffset(buf)
 		if offset < 0 {

--- a/pkg/uefi/file.go
+++ b/pkg/uefi/file.go
@@ -406,8 +406,10 @@ func NewFile(buf []byte) (*File, error) {
 		return nil, fmt.Errorf("File size too big! File with GUID: %v has length %v, but is only %v bytes big",
 			f.Header.GUID, f.Header.ExtendedSize, buflen)
 	}
-	// Slice buffer to the correct size.
-	f.buf = buf[:f.Header.ExtendedSize]
+	// Copy out the buffer.
+	newBuf := buf[:f.Header.ExtendedSize]
+	f.buf = make([]byte, f.Header.ExtendedSize)
+	copy(f.buf, newBuf)
 
 	// Parse sections
 	if _, ok := SupportedFiles[f.Header.Type]; !ok {

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -248,8 +248,10 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	fv.fvType = FVGUIDs[fv.FileSystemGUID]
 	fv.FVOffset = fvOffset
 
-	// slice the buffer
-	fv.buf = data[:fv.Length]
+	// copy out the buffer.
+	newBuf := data[:fv.Length]
+	fv.buf = make([]byte, fv.Length)
+	copy(fv.buf, newBuf)
 
 	// Parse the files.
 	// TODO: handle fv data alignment.

--- a/pkg/uefi/flashdescriptormap.go
+++ b/pkg/uefi/flashdescriptormap.go
@@ -11,8 +11,6 @@ import (
 )
 
 const (
-	// FlashDescriptorMapSize is the size in bytes of the Intel flash descriptor
-	FlashDescriptorMapSize = 0x1000
 	// FlashDescriptorMapMaxBase is the maximum base address for a flash descriptor
 	// region
 	FlashDescriptorMapMaxBase = 0xe0
@@ -45,12 +43,6 @@ type FlashDescriptorMap struct {
 
 // NewFlashDescriptorMap initializes a FlashDescriptor from a slice of bytes.
 func NewFlashDescriptorMap(buf []byte) (*FlashDescriptorMap, error) {
-	if len(buf) < FlashDescriptorMapSize {
-		return nil, fmt.Errorf("Flash Descriptor Map size too small: expected %v bytes, got %v",
-			FlashDescriptorMapSize,
-			len(buf),
-		)
-	}
 	r := bytes.NewReader(buf)
 	var descriptor FlashDescriptorMap
 	if err := binary.Read(r, binary.LittleEndian, &descriptor); err != nil {

--- a/pkg/uefi/rawregion.go
+++ b/pkg/uefi/rawregion.go
@@ -28,7 +28,9 @@ func (rr *RawRegion) FlashRegion() (fr *FlashRegion) {
 
 // NewRawRegion creates a new region.
 func NewRawRegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error) {
-	rr := &RawRegion{buf: buf, flashRegion: r, RegionType: rt}
+	rr := &RawRegion{flashRegion: r, RegionType: rt}
+	rr.buf = make([]byte, len(buf))
+	copy(rr.buf, buf)
 	return rr, nil
 }
 

--- a/pkg/uefi/section.go
+++ b/pkg/uefi/section.go
@@ -311,8 +311,10 @@ func NewSection(buf []byte, fileOrder int) (*Section, error) {
 		return nil, fmt.Errorf("section size mismatch! Section has size %v, but buffer is %v bytes big",
 			s.Header.ExtendedSize, buflen)
 	}
-	// Slice buffer to the correct size.
-	s.buf = buf[:s.Header.ExtendedSize]
+	// Copy out the buffer.
+	newBuf := buf[:s.Header.ExtendedSize]
+	s.buf = make([]byte, s.Header.ExtendedSize)
+	copy(s.buf, newBuf)
 
 	// Section type specific data
 	switch s.Header.Type {


### PR DESCRIPTION
We were getting corruption on some bioses due to the slices sharing an
underlying array. Also fixed a silent bug where the IFD was indexing
bytes 0x20 to 0x4116.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>