### PR TITLE
Region Fix

### DIFF
--- a/pkg/uefi/biosregion.go
+++ b/pkg/uefi/biosregion.go
@@ -57,8 +57,8 @@ type BIOSRegion struct {
 	ExtractPath string
 	Length      uint64
 	// This is a pointer to the FlashRegion struct laid out in the ifd.
-	flashRegion *FlashRegion
-	RegionType  FlashRegionType
+	FRegion    *FlashRegion
+	RegionType FlashRegionType
 }
 
 // Type returns the flash region type.
@@ -68,19 +68,19 @@ func (br *BIOSRegion) Type() FlashRegionType {
 
 // SetFlashRegion sets the Flash Region.
 func (br *BIOSRegion) SetFlashRegion(fr *FlashRegion) {
-	br.flashRegion = fr
+	br.FRegion = fr
 }
 
 // FlashRegion gets the Flash Region.
 func (br *BIOSRegion) FlashRegion() (fr *FlashRegion) {
-	return br.flashRegion
+	return br.FRegion
 }
 
 // NewBIOSRegion parses a sequence of bytes and returns a Region
 // object, if a valid one is passed, or an error. It also points to the
 // Region struct uncovered in the ifd.
 func NewBIOSRegion(buf []byte, r *FlashRegion, _ FlashRegionType) (Region, error) {
-	br := BIOSRegion{flashRegion: r, Length: uint64(len(buf)),
+	br := BIOSRegion{FRegion: r, Length: uint64(len(buf)),
 		RegionType: RegionTypeBIOS}
 	var absOffset uint64
 

--- a/pkg/uefi/rawregion.go
+++ b/pkg/uefi/rawregion.go
@@ -11,24 +11,24 @@ type RawRegion struct {
 	// Metadata for extraction and recovery
 	ExtractPath string
 	// This is a pointer to the FlashRegion struct laid out in the ifd.
-	flashRegion *FlashRegion
+	FRegion *FlashRegion
 	// Region Type as per the IFD
 	RegionType FlashRegionType
 }
 
 // SetFlashRegion sets the flash region.
 func (rr *RawRegion) SetFlashRegion(fr *FlashRegion) {
-	rr.flashRegion = fr
+	rr.FRegion = fr
 }
 
 // FlashRegion gets the flash region.
 func (rr *RawRegion) FlashRegion() (fr *FlashRegion) {
-	return rr.flashRegion
+	return rr.FRegion
 }
 
 // NewRawRegion creates a new region.
 func NewRawRegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error) {
-	rr := &RawRegion{flashRegion: r, RegionType: rt}
+	rr := &RawRegion{FRegion: r, RegionType: rt}
 	rr.buf = make([]byte, len(buf))
 	copy(rr.buf, buf)
 	return rr, nil


### PR DESCRIPTION
This fixes the extract, assemble and reextract tests for images with
ifds and regions. Previously the assembly was broken due to json
umarshalling of an interface.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>