### PR TITLE
Fix replacepe32

### DIFF
--- a/pkg/visitors/replacepe32_test.go
+++ b/pkg/visitors/replacepe32_test.go
@@ -17,7 +17,7 @@ func TestReplacePE32(t *testing.T) {
 	// Apply the visitor.
 	replace := &ReplacePE32{
 		Predicate: FindFileGUIDPredicate(*testGUID),
-		NewPE32:   []byte("banana"),
+		NewPE32:   []byte("MZbanana"),
 	}
 	if err := replace.Run(f); err != nil {
 		t.Fatal(err)
@@ -33,7 +33,7 @@ func TestReplacePE32(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("got %d matches; expected 1", len(results))
 	}
-	want := []byte{0x0a, 0x00, 0x00, byte(uefi.SectionTypePE32), 'b', 'a', 'n', 'a', 'n', 'a'}
+	want := []byte{0x0c, 0x00, 0x00, byte(uefi.SectionTypePE32), 'M', 'Z', 'b', 'a', 'n', 'a', 'n', 'a'}
 	file, ok := results[0].(*uefi.File)
 	if !ok {
 		t.Fatalf("did not match a file, got type :%T", file)
@@ -41,5 +41,42 @@ func TestReplacePE32(t *testing.T) {
 	got := file.Sections[0].Buf()
 	if !reflect.DeepEqual(want, got) {
 		t.Fatalf("want %v; got %v", want, got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	f := parseImage(t)
+
+	var tests = []struct {
+		name    string
+		newPE32 []byte
+		match   string
+		err     string
+	}{
+		{"No Matches", []byte("MZbanana"), "no-match-string",
+			"no matches found for replacement"},
+		{"Multiple Matches", []byte("MZbanana"), ".*",
+			"multiple matches found! There can be only one. Use find to list all matches"},
+		{"Not PE32", []byte("banana"), ".*",
+			"supplied binary is not a valid pe32 image"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Apply the visitor.
+			pred, err := FindFilePredicate(test.match)
+			if err != nil {
+				t.Fatal(err)
+			}
+			replace := &ReplacePE32{
+				Predicate: pred,
+				NewPE32:   test.newPE32,
+			}
+			err = replace.Run(f)
+			if err == nil {
+				t.Fatalf("Expected Error (%v), got nil", test.err)
+			} else if err.Error() != test.err {
+				t.Fatalf("Mismatched Error: Expected %v, got %v", test.err, err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
This ensures that replace_pe32 errors out if it can trivially detect
that the supplied binary is not a pe32 binary. It also errors out if
there is 0 or more than 1 match for replacement.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>