### PR TITLE
Add a comment command

### DIFF
--- a/pkg/visitors/comment.go
+++ b/pkg/visitors/comment.go
@@ -1,0 +1,36 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/linuxboot/fiano/pkg/uefi"
+)
+
+// Comment holds the io.Writer and args for a comment
+type Comment struct {
+	W io.Writer
+	s string
+}
+
+// Run wraps Visit and performs some setup and teardown tasks.
+func (v *Comment) Run(f uefi.Firmware) error {
+	fmt.Fprintf(v.W, "%s\n", v.s)
+	return nil
+}
+
+// Visit applies the Comment visitor to any Firmware type.
+func (v *Comment) Visit(f uefi.Firmware) error {
+	return nil
+}
+
+func init() {
+	RegisterCLI("comment", "Print one arg", 1, func(args []string) (uefi.Visitor, error) {
+		return &Comment{W: os.Stdout, s: args[0]}, nil
+	})
+}

--- a/pkg/visitors/comment_test.go
+++ b/pkg/visitors/comment_test.go
@@ -1,0 +1,18 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package visitors
+
+import (
+	"testing"
+)
+
+func TestComment(t *testing.T) {
+	f := parseImage(t)
+	results := comment(t, f)
+
+	if len(results) != 0 {
+		t.Fatalf("got %d matches; expected 0", len(results))
+	}
+}

--- a/pkg/visitors/helpers_test.go
+++ b/pkg/visitors/helpers_test.go
@@ -5,6 +5,7 @@
 package visitors
 
 import (
+	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -35,4 +36,16 @@ func find(t *testing.T, f uefi.Firmware, guid *guid.GUID) []uefi.Firmware {
 		t.Fatal(err)
 	}
 	return find.Matches
+}
+
+func comment(t *testing.T, f uefi.Firmware) []uefi.Firmware {
+	var b bytes.Buffer
+	c := &Comment{W: &b, s: "hi"}
+	if err := c.Run(f); err != nil {
+		t.Fatal(err)
+	}
+	if b.String() != "hi\n" {
+		t.Fatalf("Comment: go %q, wanted 'hi'", b.String())
+	}
+	return nil
 }


### PR DESCRIPTION
I keep hitting the fact that this would make my current testing
a LOT easier.

I can have a whole list of remove commands, and I want to leave the name
in there, so I don't forget I'm leaving it in, and changing
remove xxx.dxe
to
comment xxx.dxe

is just too handy. Until we have forth that is.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>