### PR TITLE
integration: Test JSON changes against golden

### DIFF
--- a/integration/roms/OVMF.json
+++ b/integration/roms/OVMF.json
@@ -1,0 +1,5802 @@
+{
+	"Elements": [
+		{
+			"Type": "*uefi.FirmwareVolume",
+			"Value": {
+				"FileSystemGUID": {
+					"GUID": "FFF12B8D-7696-4C8B-A985-2747075B4F50"
+				},
+				"Length": 540672,
+				"Signature": 1213613663,
+				"Attributes": 327423,
+				"HeaderLen": 72,
+				"Checksum": 47279,
+				"ExtHeaderOffset": 0,
+				"Revision": 2,
+				"Blocks": [
+					{
+						"Count": 132,
+						"Size": 4096
+					}
+				],
+				"FVName": {
+					"GUID": "00000000-0000-0000-0000-000000000000"
+				},
+				"ExtHeaderSize": 0,
+				"DataOffset": 72,
+				"FVOffset": 0,
+				"ExtractPath": "",
+				"Resizable": false
+			}
+		},
+		{
+			"Type": "*uefi.FirmwareVolume",
+			"Value": {
+				"FileSystemGUID": {
+					"GUID": "8C8CE578-8A3D-4F1C-9935-896185C32DD3"
+				},
+				"Length": 3440640,
+				"Signature": 1213613663,
+				"Attributes": 327423,
+				"HeaderLen": 72,
+				"Checksum": 25331,
+				"ExtHeaderOffset": 96,
+				"Revision": 2,
+				"Blocks": [
+					{
+						"Count": 840,
+						"Size": 4096
+					}
+				],
+				"FVName": {
+					"GUID": "48DB5E17-707C-472D-91CD-1613E7EF51B0"
+				},
+				"ExtHeaderSize": 20,
+				"Files": [
+					{
+						"Header": {
+							"GUID": {
+								"GUID": "9E21FD93-9C72-4C15-8C4B-E77F1DB2D792"
+							},
+							"Type": 11,
+							"Attributes": 0
+						},
+						"Type": "EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE",
+						"Sections": [
+							{
+								"Header": {
+									"Type": 2
+								},
+								"Type": "EFI_SECTION_GUID_DEFINED",
+								"ExtractPath": "",
+								"TypeSpecific": {
+									"Type": 2,
+									"Header": {
+										"GUID": {
+											"GUID": "EE4E5898-3914-4259-9D6E-DC7BD79403CF"
+										},
+										"DataOffset": 24,
+										"Attributes": 1,
+										"Compression": "LZMA"
+									}
+								},
+								"Encapsulated": [
+									{
+										"Type": "*uefi.Section",
+										"Value": {
+											"Header": {
+												"Type": 25
+											},
+											"Type": "EFI_SECTION_RAW",
+											"ExtractPath": ""
+										}
+									},
+									{
+										"Type": "*uefi.Section",
+										"Value": {
+											"Header": {
+												"Type": 23
+											},
+											"Type": "EFI_SECTION_FIRMWARE_VOLUME_IMAGE",
+											"ExtractPath": "",
+											"Encapsulated": [
+												{
+													"Type": "*uefi.FirmwareVolume",
+													"Value": {
+														"FileSystemGUID": {
+															"GUID": "8C8CE578-8A3D-4F1C-9935-896185C32DD3"
+														},
+														"Length": 917504,
+														"Signature": 1213613663,
+														"Attributes": 524031,
+														"HeaderLen": 72,
+														"Checksum": 63055,
+														"ExtHeaderOffset": 96,
+														"Revision": 2,
+														"Blocks": [
+															{
+																"Count": 14,
+																"Size": 65536
+															}
+														],
+														"FVName": {
+															"GUID": "6938079B-B503-4E3D-9D24-B28337A25806"
+														},
+														"ExtHeaderSize": 20,
+														"Files": [
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "1B45CC0A-156A-428A-AF62-49864DA0E6E6"
+																	},
+																	"Type": 2,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FREEFORM",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "52C05B14-0B98-496C-BC3B-04B50211D680"
+																	},
+																	"Type": 4,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEI_CORE",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PeiCore"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9B3ADA4F-AE56-4C24-8DEA-F03B7558AE50"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A3610442-E69F-4DF3-82CA-2360C4031A23"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9D225237-FA01-464C-A949-BAABC02D31D0"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "222C386D-5ABC-4FB4-B124-FBB82488ACF4"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "86D70125-BAA3-4296-A62F-602BEBBB9081"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "89E549B0-7CFE-449D-9BA3-10D8B2312D71"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+																	},
+																	"Type": 240,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FFS_PAD",
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "EDADEB9D-DDBA-48BD-9D22-C1C169C8C5C6"
+																	},
+																	"Type": 6,
+																	"Attributes": 16
+																},
+																"Type": "EFI_FV_FILETYPE_PEIM",
+																"ExtractPath": "",
+																"DataOffset": 24
+															}
+														],
+														"DataOffset": 120,
+														"FVOffset": 0,
+														"ExtractPath": "",
+														"Resizable": true
+													}
+												}
+											]
+										}
+									},
+									{
+										"Type": "*uefi.Section",
+										"Value": {
+											"Header": {
+												"Type": 25
+											},
+											"Type": "EFI_SECTION_RAW",
+											"ExtractPath": ""
+										}
+									},
+									{
+										"Type": "*uefi.Section",
+										"Value": {
+											"Header": {
+												"Type": 23
+											},
+											"Type": "EFI_SECTION_FIRMWARE_VOLUME_IMAGE",
+											"ExtractPath": "",
+											"Encapsulated": [
+												{
+													"Type": "*uefi.FirmwareVolume",
+													"Value": {
+														"FileSystemGUID": {
+															"GUID": "8C8CE578-8A3D-4F1C-9935-896185C32DD3"
+														},
+														"Length": 10485760,
+														"Signature": 1213613663,
+														"Attributes": 327423,
+														"HeaderLen": 72,
+														"Checksum": 62766,
+														"ExtHeaderOffset": 96,
+														"Revision": 2,
+														"Blocks": [
+															{
+																"Count": 160,
+																"Size": 65536
+															}
+														],
+														"FVName": {
+															"GUID": "7CB8BDC9-F8EB-4F34-AAEA-3EE4AF6516A1"
+														},
+														"ExtHeaderSize": 20,
+														"Files": [
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FC510EE7-FFDC-11D4-BD41-0080C73C8881"
+																	},
+																	"Type": 2,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FREEFORM",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "D6A2CB7F-6A18-4E2F-B43B-9920A733700A"
+																	},
+																	"Type": 5,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DXE_CORE",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DxeCore"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "D93CE3D8-A7EB-4730-8C8E-CC466A9ECC3C"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ReportStatusCodeRouterRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "6C2004EF-4E0E-4BE4-B14C-340EB4AA5891"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "86212936-0E76-41C8-A03A-2AF2FC1C39E2"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "StatusCodeHandlerRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "80CF7257-87AB-47F9-A3FE-D50B76D89541"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PcdDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "B601F8C4-43B7-4784-95B1-F4226CB40CEE"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "RuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F80697E9-7FD6-4665-8646-88E33EF71DFC"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SecurityStubDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "13AC6DD0-73D0-11D4-B06B-00AA00BD6DE7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "EbcDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "79CA4208-BBA1-4A9A-8456-E1E66A81484E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Legacy8259"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A19B1FE7-C1BC-49F8-875F-54A5D542443F"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "CpuIo2Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "1A1E4886-9517-440E-9FDE-3BE44CEE2136"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "CpuDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F2765DEC-6B41-11D5-8E71-00902707B35E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "26BACCB1-6F42-11D4-BCE7-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "38321DBA-4FE0-4E17-8AEC-413055EAEDC1"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Timer"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F6697AC4-A776-4EE1-B643-1FEFF2B615BB"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IncompatiblePciDeviceSupportDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "11A6EDF6-A9BE-426D-A6CC-B22FE51D9224"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PciHotPlugInitDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "128FB770-5E79-4176-9E51-9BB268A17DD1"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "AD61F191-AE5F-4C0E-B9FA-E869D288C64F"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "26BACCB2-6F42-11D4-BCE7-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "26BACCB1-6F42-11D4-BCE7-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PciHostBridgeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "93B80004-9FB3-11D4-9A3A-0090273FC14D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PciBusDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "4B28E4C7-FF36-4E10-93CF-A82159E777C5"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ResetSystemRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "C8339973-A563-4561-B858-D8476F9DEFC4"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Metronome"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "378D7B65-8DA9-4773-B6E4-A47826A833E1"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "1E5668E2-8481-11D4-BCF1-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "6441F818-6362-4E44-B570-7DBA31DD2453"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PcRtc"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "33CB97AF-6C33-4C42-986B-07581FA366D4"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "BlockMmioToBlockIoDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "83DD3B39-7CAF-4FAC-A542-E050B767E3A7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioPciDeviceDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "0170F60C-1D40-4651-956D-F0BD9879D527"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Virtio10"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "11D92DFB-3CA9-4F93-BA2E-4780ED3E03B5"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioBlkDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FAB5D4F4-83C0-4AAF-8480-442D11DF6CEA"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioScsiDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "58E26F0D-CBAC-4BBA-B70F-18221415665A"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioRngDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "CF569F50-DE44-4F54-B4D7-F4AE25CDA599"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "XenIoPciDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "565EC8BA-A484-11E3-802B-B8AC6F7D65E6"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "XenBusDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "8C2487EA-9AF3-11E3-B966-B8AC6F7D65E6"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "XenPvBlkDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F099D67F-71AE-4C36-B2A3-DCEB0EB2B7D8"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "26BACCB3-6F42-11D4-BCE7-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "WatchdogTimer"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "AD608272-D07F-4964-801E-7BD3B7888652"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "1E5668E2-8481-11D4-BCF1-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "6441F818-6362-4E44-B570-7DBA31DD2453"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "MonotonicCounterRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "42857F0A-13F2-4B21-8A23-53D3F714B840"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "6441F818-6362-4E44-B570-7DBA31DD2453"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "CapsuleRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "51CCF399-4FDF-4E55-A45B-E123F84D456A"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ConPlatformDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "408EDCEC-CF6D-477C-A5A8-B4844E3DE281"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ConSplitterDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "CCCB0C28-4B24-11D5-9A5A-0090273FC14D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "GraphicsConsoleDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9E863906-A40F-4875-977F-5B93FF237FC6"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "TerminalDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "EBF8ED7C-0DD1-4787-84F1-F48D537DCACF"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "B9D4C360-BCFB-4F9B-9298-53C136982258"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DriverHealthManagerDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "6D33944A-EC75-4855-A54D-809C75241F6C"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "TRUE"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "6441F818-6362-4E44-B570-7DBA31DD2453"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "BdsDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "462CAA21-7614-4503-836E-8AB6F4662331"
+																	},
+																	"Type": 9,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_APPLICATION",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UiApp"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9B680FCE-AD6B-4F3A-B60B-F59899003443"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "TRUE"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DevicePathDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "79E4A61C-ED73-4312-94FE-E3E7563362A9"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PrintDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "6B38F7B4-AD98-40E9-9093-ACA2B5A253C4"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DiskIoDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "1FA1F39E-FEFF-4AAE-BD7B-38A070A3B609"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PartitionDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "28A03FF4-12B3-4305-A417-BB1A4F94081E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "B9D4C360-BCFB-4F9B-9298-53C136982258"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "RamDiskDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "CD3BAFB6-50FB-4FE8-8E4E-AB74D2C1A600"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "EnglishDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "0167CCC4-D0F7-4F21-A3EF-9E64B7CDCE8B"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ScsiBus"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "0A66E322-3740-4CCE-AD62-BD172CECCA35"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ScsiDisk"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "021722D8-522B-4079-852A-FE44C2C13F49"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SataController"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "5E523CB4-D397-4986-87BD-A6DD8B22F455"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "AtaAtapiPassThruDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "19DF145A-B1D4-453F-8507-38816676D7F6"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "AtaBusDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "5BE3BDF4-53CF-46A3-A6A9-73C34A6E5EE3"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "NvmExpressDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "348C4D62-BFBD-4882-9ECE-C80BB1C4783B"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "HiiDatabase"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "EBF342FE-B1D3-4EF8-957C-8048606FF671"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SetupBrowser"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "E660EA85-058E-4B55-A54B-F02F83A24707"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "A770C357-B693-4E6D-A6CF-D21C728E550B"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DisplayEngine"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "96B5C032-DF4C-4B6E-8232-438DCF448D0E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "NullMemoryTestDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "38A0EC22-FBE7-4911-8BC1-176E0D6C1DBD"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IsaAcpi"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "240612B5-A063-11D4-9A3A-0090273FC14D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IsaBusDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "93B80003-9FB3-11D4-9A3A-0090273FC14D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IsaSerialDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "3DC82376-637B-40A6-A8FC-A565417F2C38"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Ps2KeyboardDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "0ABD8284-6DA3-4616-971A-83A5148067BA"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IsaFloppyDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F9D88642-0737-49BC-81B5-6889CD57D9EA"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "TRUE"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SmbiosDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "4110465D-5FF3-4F4B-B580-24ED0D06747A"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "03583FF6-CB36-4940-947E-B9B39F4AFAF7"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SmbiosPlatformDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9622E42C-8E38-4A08-9E8F-54F784652F6B"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "AcpiTableDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "49970331-E3FA-4637-9ABC-3B7868676970"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "FFE06BDD-6107-46A6-7BB2-5A9C7EC5275C"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "AcpiPlatform"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "7E374E25-8E01-4FEE-87F2-390C23C606CD"
+																	},
+																	"Type": 2,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_FREEFORM",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "BDCE85BB-FBAA-4F4E-9264-501A2C249581"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "TRUE"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "S3SaveStateDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FA20568B-548B-4B2B-81EF-1BA08D4A3CEC"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "BD445D79-B7AD-4F04-9AD8-29BD2040EB3C"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "4E939DE9-D948-4B0F-88ED-E6E1CE517C1E"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "F8775D50-8ABD-4ADF-92AC-853E51F6C8DC"
+																				}
+																			},
+																			{
+																				"OpCode": "OR"
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "BootScriptExecutorDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "B8E62775-BB0A-43F0-A843-5BE8B14F8CCD"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "BootGraphicsResourceTableDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "961578FE-B6B7-44C3-AF35-6BC705CD2B1F"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Fat"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A487A478-51EF-48AA-8794-7BEE2A0562F1"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "tftpDynamicCommand"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "7C04A583-9E3E-4F1C-AD65-E05268D0B4D1"
+																	},
+																	"Type": 9,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_APPLICATION",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Shell"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "F74D20EE-37E7-48FC-97F7-9B1047749C69"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "1A1241E6-8F19-41A9-BC0E-E8EF39E06546"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "LogoDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A2F436EA-A127-4EF8-957C-8048606FF670"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "SnpDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A210F973-229D-4F4D-AA37-9895E6C9EABA"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "DpcDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "025BBFC7-E6A9-4B8B-82AD-6815A1AEAF4A"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "MnpDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "E4F61863-FE2C-4B56-A8F4-08519BC439DF"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VlanConfigDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "529D3F93-E8E9-4E73-B1E1-BDF6A9D50113"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "ArpDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "94734718-0BBC-47FB-96A5-EE7A5AE6A2AD"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Dhcp4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9FB1A1F3-3B71-4324-B39A-745CBB015FFF"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Ip4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "DC3641B8-2FA8-4ED3-BC1F-F9962A03454B"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Mtftp4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Udp4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "6D6963AB-906D-4A65-A7CA-BD40E5D6AF4D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "Tcp4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "3B1DEAB5-C75D-442E-9238-8E2FFB62B0BB"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UefiPxe4BcDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "4579B72D-7EC4-4DD4-8486-083C86B182A7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IScsi4Dxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "A92CDB4B-82F1-4E0B-A516-8A655D371524"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioNetDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "2FB92EFA-2EE0-4BAE-9EB6-7464125E1EF7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UhciDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "BDFE430E-8F2A-4DB0-9991-6F856594777E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "EhciDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "B7F50E91-A759-412C-ADE4-DCD03E7F7C28"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "XhciDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "240612B7-A063-11D4-9A3A-0090273FC14D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UsbBusDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "2D2E62CF-9ECF-43B7-8219-94E7FC713DFE"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UsbKbDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "9FB4B4A7-42C0-4BCD-8540-9BCC6711F83E"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "UsbMassStorageDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "E3752948-B9A1-4770-90C4-DF41C38986BE"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "QemuVideoDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "D6099B94-CD97-4CC5-8714-7F6312701A8A"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VirtioGpuDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "D9DCC5DF-4007-435E-9098-8970935504B2"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "587E72D7-CC50-4F79-8209-CA291FC1A10F"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "EF9FC172-A1B2-4693-B327-6D32FC416042"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "1E5668E2-8481-11D4-BCF1-0080C73C8881"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "6441F818-6362-4E44-B570-7DBA31DD2453"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0FD96974-23AA-4CDC-B9CB-98D17750322A"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 25
+																		},
+																		"Type": "EFI_SECTION_RAW",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "PlatformDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "2EC9DA37-EE35-4DE9-86C5-6D9A81DC38A7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "AmdSevDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "8657015B-EA43-440D-949A-AF3BE365C0FC"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "IoMmuDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "733CBAC2-B23F-4B92-BC8E-FB01CE5907B7"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "FvbServicesRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "22DC2B60-FE40-42AC-B01F-3AB1FAD9AAD8"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "EmuVariableFvbRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "FE5CEA76-4F72-49E8-986F-2CD899DFFE5D"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "8F644FA9-E850-4DB1-9CE2-0B44698E8DA4"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "B7DFB4E1-052F-449F-87BE-9818FC91B733"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "FaultTolerantWriteDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															},
+															{
+																"Header": {
+																	"GUID": {
+																		"GUID": "CBD2E4D5-7068-4FF5-B462-9822B4AD8D60"
+																	},
+																	"Type": 7,
+																	"Attributes": 0
+																},
+																"Type": "EFI_FV_FILETYPE_DRIVER",
+																"Sections": [
+																	{
+																		"Header": {
+																			"Type": 19
+																		},
+																		"Type": "EFI_SECTION_DXE_DEPEX",
+																		"ExtractPath": "",
+																		"DepEx": [
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "13A3F0F6-264A-3EF0-F2E0-DEC512342F34"
+																				}
+																			},
+																			{
+																				"OpCode": "PUSH",
+																				"GUID": {
+																					"GUID": "0379BE4E-D706-437D-B037-EDB82FB772A4"
+																				}
+																			},
+																			{
+																				"OpCode": "AND"
+																			},
+																			{
+																				"OpCode": "END"
+																			}
+																		]
+																	},
+																	{
+																		"Header": {
+																			"Type": 16
+																		},
+																		"Type": "EFI_SECTION_PE32",
+																		"ExtractPath": ""
+																	},
+																	{
+																		"Header": {
+																			"Type": 21
+																		},
+																		"Type": "EFI_SECTION_USER_INTERFACE",
+																		"ExtractPath": "",
+																		"Name": "VariableRuntimeDxe"
+																	},
+																	{
+																		"Header": {
+																			"Type": 20
+																		},
+																		"Type": "EFI_SECTION_VERSION",
+																		"ExtractPath": ""
+																	}
+																],
+																"ExtractPath": "",
+																"DataOffset": 24
+															}
+														],
+														"DataOffset": 120,
+														"FVOffset": 0,
+														"ExtractPath": "",
+														"Resizable": true
+													}
+												}
+											]
+										}
+									}
+								]
+							}
+						],
+						"ExtractPath": "",
+						"DataOffset": 24
+					}
+				],
+				"DataOffset": 120,
+				"FVOffset": 540672,
+				"ExtractPath": "",
+				"Resizable": false
+			}
+		},
+		{
+			"Type": "*uefi.FirmwareVolume",
+			"Value": {
+				"FileSystemGUID": {
+					"GUID": "8C8CE578-8A3D-4F1C-9935-896185C32DD3"
+				},
+				"Length": 212992,
+				"Signature": 1213613663,
+				"Attributes": 327423,
+				"HeaderLen": 72,
+				"Checksum": 42552,
+				"ExtHeaderOffset": 96,
+				"Revision": 2,
+				"Blocks": [
+					{
+						"Count": 52,
+						"Size": 4096
+					}
+				],
+				"FVName": {
+					"GUID": "763BED0D-DE9F-48F5-81F1-3E90E1B1A015"
+				},
+				"ExtHeaderSize": 20,
+				"Files": [
+					{
+						"Header": {
+							"GUID": {
+								"GUID": "DF1CCEF6-F301-4A63-9661-FC6030DCC880"
+							},
+							"Type": 3,
+							"Attributes": 0
+						},
+						"Type": "EFI_FV_FILETYPE_SECURITY_CORE",
+						"Sections": [
+							{
+								"Header": {
+									"Type": 16
+								},
+								"Type": "EFI_SECTION_PE32",
+								"ExtractPath": ""
+							},
+							{
+								"Header": {
+									"Type": 21
+								},
+								"Type": "EFI_SECTION_USER_INTERFACE",
+								"ExtractPath": "",
+								"Name": "SecMain"
+							},
+							{
+								"Header": {
+									"Type": 20
+								},
+								"Type": "EFI_SECTION_VERSION",
+								"ExtractPath": ""
+							}
+						],
+						"ExtractPath": "",
+						"DataOffset": 24
+					},
+					{
+						"Header": {
+							"GUID": {
+								"GUID": "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+							},
+							"Type": 240,
+							"Attributes": 0
+						},
+						"Type": "EFI_FV_FILETYPE_FFS_PAD",
+						"ExtractPath": "",
+						"DataOffset": 24
+					},
+					{
+						"Header": {
+							"GUID": {
+								"GUID": "1BA0062E-C779-4582-8566-336AE8F78F09"
+							},
+							"Type": 1,
+							"Attributes": 8
+						},
+						"Type": "EFI_FV_FILETYPE_RAW",
+						"ExtractPath": "",
+						"DataOffset": 24
+					}
+				],
+				"DataOffset": 120,
+				"FVOffset": 3981312,
+				"ExtractPath": "",
+				"Resizable": false
+			}
+		}
+	],
+	"ExtractPath": "",
+	"Length": 4194304,
+	"FRegion": null,
+	"RegionType": 0
+}


### PR DESCRIPTION
We were unable to devise a satisfactory way to automatically test
extraction on entire images. This solution requires approximately a
minute of work to compare the new JSON output against the previous
JSON for each commit.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>