### PR TITLE
Forth utk

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,18 +2,19 @@
 
 
 [[projects]]
-  digest = "1:51ceb357de5c06371be8becad34cff7e22041cfbed039631a22e17c1600af422"
+  digest = "1:21274448d9cdf3e24f6ae5b43bd38a632f48fede5cd23299dae6eae816b3220b"
   name = "github.com/u-root/u-root"
   packages = [
+    "pkg/forth",
     "pkg/golang",
     "pkg/testutil",
   ]
   pruneopts = "UT"
-  revision = "70e4254bbc315a0c6bf758f1737ca6998435d3a2"
-  version = "v2.0.0"
+  revision = "240c641ceb065925ebecd1a406f64161f71afaa9"
+  version = "v3.0.0"
 
 [[projects]]
-  digest = "1:ba8028944baec941af3e7e7d9a51b3161a7168a042188b058da662bfc33fd1aa"
+  digest = "1:74424672efb1cc0a95c80db0787e1a791ff562fa990facbd1530296f4f9ca7a7"
   name = "github.com/ulikunitz/xz"
   packages = [
     "internal/hash",
@@ -21,8 +22,8 @@
     "lzma",
   ]
   pruneopts = "UT"
-  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
-  version = "v0.5.4"
+  revision = "590df8077fbcb06ad62d7714da06c00e5dd2316d"
+  version = "v0.5.5"
 
 [[projects]]
   digest = "1:fb8be2f4db4c5f3fa4b93ec808502d5933c7cf8d8fa285b32ba8c0102c309850"
@@ -46,6 +47,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/u-root/u-root/pkg/forth",
     "github.com/u-root/u-root/pkg/testutil",
     "github.com/ulikunitz/xz/lzma",
     "golang.org/x/text/encoding/unicode",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,4 +31,4 @@
 
 [[constraint]]
   name = "github.com/u-root/u-root"
-  version = "2.0.0"
+  version = "3.0.0"

--- a/cmds/futk/futk.go
+++ b/cmds/futk/futk.go
@@ -1,0 +1,564 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// futk is a forth-inspired infterface to utk.
+// It is in a state of flux just now.
+// Typical usage, and note that our first command is in argv, and they could all (or none) be in argv:
+// rminnich@uroot:~/go/src/github.com/linuxboot/fiano/cmds/futk$ ./futk 7106V100.ROM fv # fv reads in a firmware volume
+//    2018/11/21 09:14:29 Found 413 things
+//    413
+//    OK Tcp|Pxe|Udp ix r r tag
+//    [6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B:EFI_FV_FILETYPE_DRIVER:Udp4Dxe D912C7BC-F098-4367-92BA-E911083C7B0E:EFI_FV_FILETYPE_DRIVER:Udp6Dxe B95E9FDA-26DE-48D2-8807-1F9107AC5E3A:EFI_FV_FILETYPE_DRIVER:UefiPxeBcDxe 1A7E4468-2F55-4A56-903C-01265EB7622B:EFI_FV_FILETYPE_DRIVER:TcpDxe]
+//    OK Tcp|Pxe|Udp ix status
+//    1A7E4468-2F55-4A56-903C-01265EB7622B:EFI_FV_FILETYPE_DRIVER:TcpDxe: tags map[r:r]
+//    6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B:EFI_FV_FILETYPE_DRIVER:Udp4Dxe: tags map[r:r]
+//    D912C7BC-F098-4367-92BA-E911083C7B0E:EFI_FV_FILETYPE_DRIVER:Udp6Dxe: tags map[r:r]
+//    B95E9FDA-26DE-48D2-8807-1F9107AC5E3A:EFI_FV_FILETYPE_DRIVER:UefiPxeBcDxe: tags map[r:r]
+//
+//    OK bzImage.uroot splat
+//    [7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell]
+//    OK go
+//    [/tmp/futkblacklist753009682 /tmp/futkrom522877513]
+//    OK
+// The r tags means those DXEs are removed before writing.
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/linuxboot/fiano/pkg/uefi"
+	"github.com/linuxboot/fiano/pkg/visitors"
+	"github.com/u-root/u-root/pkg/forth"
+)
+
+const (
+	keep    = "k"
+	remove  = "r"
+	removed = "R"
+)
+
+// Track information about files we found.
+// We record the res used to find it and
+// the states we assigned to it.
+type (
+	info struct {
+		GUID  string
+		name  string
+		ftype uefi.FVFileType
+		tags  map[string]string
+	}
+	cmd struct {
+		c string
+		h string
+		f forth.Op
+	}
+)
+
+var (
+	fv uefi.Firmware
+	// Track the files we have marked as keep, remove, or unknown.
+	files   = map[uefi.Firmware]*info{}
+	notouch = map[uefi.FVFileType]bool{
+		uefi.FVFileTypeRaw:                true,
+		uefi.FVFileTypeFreeForm:           true,
+		uefi.FVFileTypeSECCore:            true,
+		uefi.FVFileTypePEICore:            true,
+		uefi.FVFileTypeDXECore:            true,
+		uefi.FVFileTypePEIM:               true,
+		uefi.FVFileTypeDriver:             false,
+		uefi.FVFileTypeCombinedPEIMDriver: true,
+		uefi.FVFileTypeApplication:        false,
+		uefi.FVFileTypeSMM:                true,
+		uefi.FVFileTypeVolumeImage:        true,
+		uefi.FVFileTypeCombinedSMMDXE:     true,
+		uefi.FVFileTypeSMMCore:            true,
+		uefi.FVFileTypeSMMStandalone:      true,
+		uefi.FVFileTypeSMMCoreStandalone:  true,
+		uefi.FVFileTypeOEMMin:             true,
+		uefi.FVFileTypeOEMMax:             true,
+		uefi.FVFileTypeDebugMin:           true,
+		uefi.FVFileTypeDebugMax:           true,
+		uefi.FVFileTypePad:                true,
+		// uefi.FVFileTypeFFSMin:             true, same as Pad, bug?
+		uefi.FVFileTypeFFSMax: true,
+	}
+
+	r = &visitors.Remove{
+		Pad: false,
+	}
+	commands []cmd
+)
+
+func init() {
+	commands = []cmd{
+		{"fv", "Read in the firmware volume named by TOS[0]", readFV},
+		{"find", "Find the REs at TOS[[0]", find},
+		{"ix", "Using the RE at TOS[0], create and push a []*info", ix},
+		{"status", "Describe the status of the []*info at TOS[0]", status},
+		{"bad", "List names which are marked for both keep and remove", bad},
+		{"tag", "Tag []*info at TOS[2] with tag at TOS[1] and value TOS[0]", tag},
+		{"saverom", "Write the firmware volume to a file named by TOS[0]", saverom},
+		{"untag", "Remove the tag at TOS[0] for the []info at TOS[1]", untag},
+		{"go", "deprecated -- do not use", dit},
+		{"run", "Run the UTK command at TOS[0] with the args from the stack", run},
+		{"splat", "Replace files named .*Shell.* with the file at TOS[0]", splat},
+		{"clean", "Clean the image. Runs DXECLEAN script for each iteration. Leaves artifact names in a []string at TOS[0]", clean},
+		// TODO: new words for forth package to move to u-root.
+		{"drop", "Drop TOS[0]", drop},
+		{"help", "Print a help message", help},
+	}
+}
+func help(f forth.Forth) {
+	for _, c := range commands {
+		fmt.Printf("%s: %s\n", c.c, c.h)
+	}
+}
+
+// saverom saves the rom somewhere useful.
+func saverom(f forth.Forth) {
+	n := forth.String(f)
+	rom, err := os.Create(n)
+	if err != nil {
+		panic(err)
+	}
+	defer rom.Close()
+	var errs []string
+	for _, f := range files {
+		if _, ok := f.tags[remove]; !ok {
+			continue
+		}
+		if _, ok := f.tags[removed]; ok {
+			continue
+		}
+		log.Printf("Try to remove %v (%v)", f.name, f.GUID)
+		rp, err := visitors.FindFilePredicate(f.GUID)
+		if err != nil {
+			panic(err)
+		}
+		r.Predicate = rp
+		if err := r.Run(fv); err != nil {
+			errs = append(errs, fmt.Sprintf("%v", err))
+		}
+		if len(r.Matches) == 0 {
+			panic(fmt.Sprintf("Can't happen: %v not found", f))
+		}
+		f.tags[removed] = "saverom"
+		log.Printf("removed %v", r.Matches)
+	}
+	if errs != nil {
+		panic(errs)
+	}
+	a := &visitors.Assemble{}
+	if err := fv.Apply(a); err != nil {
+		panic(err)
+	}
+	if _, err := io.Copy(rom, bytes.NewBuffer(fv.Buf())); err != nil {
+		panic(err)
+	}
+}
+
+func drop(f forth.Forth) {
+	if !f.Empty() {
+		f.Pop()
+	}
+}
+
+// do two things.
+// create a tmp file with things removed that can be removed.
+// create a black list
+// returns a []string with the two files
+func dit(f forth.Forth) {
+	var blist string
+	var errs []string
+	for _, f := range files {
+		if _, ok := f.tags["k"]; ok {
+			blist += f.name + "\n"
+			continue
+		}
+		if _, ok := f.tags["r"]; !ok {
+			continue
+		}
+		rp, err := visitors.FindFilePredicate(f.name)
+		if err != nil {
+			panic(err)
+		}
+		r := &visitors.Remove{
+			Predicate: rp,
+			Pad:       false,
+		}
+		if err := r.Run(fv); err != nil {
+			errs = append(errs, fmt.Sprintf("%v", err))
+		}
+	}
+	if errs != nil {
+		f.Push(errs)
+		return
+	}
+	bl, err := ioutil.TempFile("", "futkblacklist")
+	if err != nil {
+		panic(err)
+	}
+	defer bl.Close()
+	rom, err := ioutil.TempFile("", "futkrom")
+	if err != nil {
+		panic(err)
+	}
+	defer rom.Close()
+	if _, err := io.Copy(bl, bytes.NewBufferString(blist)); err != nil {
+		f.Push(err)
+		return
+	}
+	a := &visitors.Assemble{}
+	if err := fv.Apply(a); err != nil {
+		f.Push(err)
+		return
+	}
+	// Can I parse my own thing?
+	_, err = uefi.Parse(fv.Buf())
+	if err != nil {
+		panic(err)
+	}
+	if _, err := io.Copy(rom, bytes.NewBuffer(fv.Buf())); err != nil {
+		f.Push(err)
+		return
+	}
+	f.Push([]string{bl.Name(), rom.Name()})
+}
+
+// Find the file name.
+// Help me out here. On what planet does anything as stupid as UEFI firmware volumes
+// look like a good idea? Just wondering.
+func name(f uefi.Firmware) (string, error) {
+	var n string
+	fp := func(f uefi.Firmware) bool {
+		switch f := f.(type) {
+		case *uefi.Section:
+			if f.Type == "EFI_SECTION_USER_INTERFACE" {
+				n = f.Name
+				return true
+			}
+		}
+		return false
+	}
+	var b bytes.Buffer
+	pred := &visitors.Find{Predicate: fp, W: &b}
+	if err := pred.Run(f); err != nil {
+		panic(err)
+	}
+
+	return n, nil
+}
+
+func readFV(f forth.Forth) {
+	n := forth.String(f)
+	image, err := ioutil.ReadFile(n)
+	if err != nil {
+		panic(err)
+	}
+	fv, err = uefi.Parse(image)
+	if err != nil {
+		panic(err)
+	}
+	// Now fill in our list.
+	fp, err := visitors.FindFilePredicate(".*")
+	if err != nil {
+		panic(err)
+	}
+	var b bytes.Buffer
+	pred := &visitors.Find{Predicate: fp, W: &b}
+	if err := pred.Run(fv); err != nil {
+		panic(err)
+	}
+	log.Printf("Found %d things", len(pred.Matches))
+	files = make(map[uefi.Firmware]*info, len(pred.Matches))
+	for _, vf := range pred.Matches {
+		var f *info
+		var g, n string
+		var t uefi.FVFileType
+		switch mfile := vf.(type) {
+		case *uefi.File:
+			t = mfile.Header.Type
+			g = fmt.Sprintf("%v", mfile.Header.GUID.String())
+			nm, err := name(mfile)
+			if err != nil {
+				log.Printf("finding name for %v: %v (warning only)", mfile, err)
+			}
+			n = fmt.Sprintf("%v:%v:%v", g, t, nm)
+			f = &info{
+				name:  n,
+				GUID:  g,
+				ftype: t,
+				tags:  map[string]string{},
+			}
+			files[vf] = f
+		}
+	}
+
+	f.Push(len(files))
+}
+
+func status(f forth.Forth) {
+	ff := f.Pop().([]*info)
+	var ret string
+	for _, f := range ff {
+		ret += fmt.Sprintf("%s: res %v\n", f.name, f.tags)
+	}
+	f.Push(ret)
+}
+
+func tag(f forth.Forth) {
+	t := forth.String(f)
+	expr := forth.String(f)
+	ff := f.Pop().([]*info)
+	var ret []string
+	for _, f := range ff {
+		if v, ok := f.tags[t]; ok {
+			ret = append(ret, fmt.Sprintf("%s: %s already marked by re %s", f.name, t, v))
+			continue
+		}
+		f.tags[t] = expr
+		ret = append(ret, f.name)
+	}
+
+	if ret != nil {
+		f.Push(ret)
+		return
+	}
+	f.Push("Nothing tagged")
+}
+
+func runit(args ...string) string {
+	ret := fmt.Sprintf("Run %v", args)
+	v, err := visitors.ParseCLI(args)
+	if err != nil {
+		panic(fmt.Sprintf("%v: %v", ret, err))
+	}
+	if err := visitors.ExecuteCLI(fv, v); err != nil {
+		panic(fmt.Sprintf("%v: %v", ret, err))
+	}
+	return ret
+}
+
+// Just run a command in the utk "cli"
+func run(f forth.Forth) {
+	var args []string
+	for _, a := range f.Stack() {
+		args = append(args, a.(string))
+	}
+	f.Reset()
+	f.Push(runit(args...))
+}
+
+// You can call run to do this; we keep it separate because
+// it's a bit more convenient
+// we can add a tag
+// we like the name splat
+func splat(f forth.Forth) {
+	kern := forth.String(f)
+	runit("replace_pe32", ".*Shell.*", kern)
+	// TODO: make shell take a []Cell
+	ret, err := forth.Eval(f, ".*Shell.* ix shell replaced tag\n")
+	if err != nil {
+		panic(err)
+	}
+	/*f.Push(".*Shell.*")
+	ix(f)
+	f.Push("shell")
+	f.Push("splat")
+	tag(f)
+	*/
+	f.Push(ret)
+}
+
+func untag(f forth.Forth) {
+	t := forth.String(f)
+	ff := f.Pop().([]*info)
+	var ret []string
+	for _, f := range ff {
+		delete(f.tags, t)
+		ret = append(ret, f.name)
+	}
+	if ret != nil {
+		f.Push(ret)
+		return
+	}
+	f.Push("nothing untagged")
+}
+
+func bad(f forth.Forth) {
+	var ret []string
+	for _, f := range files {
+		_, keeper := f.tags[keep]
+		_, remover := f.tags[remove]
+		if keeper && remover {
+			ret = append(ret, fmt.Sprintf("%s: marked for keep and remove: %v", f.name, f.tags))
+		}
+	}
+	if ret != nil {
+		f.Push(ret)
+		return
+	}
+	f.Push("Nothing bad")
+}
+
+// We create a temp directory, and, starting with the current file, create files
+// in a sequence, starting with 0 as the original.
+func clean(f forth.Forth) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigs := make(chan os.Signal, 512)
+	signal.Notify(sigs, os.Interrupt)
+	done := make(chan bool)
+	go func() {
+		for i := range sigs {
+			fmt.Println(i)
+			cancel()
+			done <- true
+		}
+	}()
+	dir, err := ioutil.TempDir("", "futk")
+	if err != nil {
+		panic(err)
+	}
+	var generation int
+	script := forth.String(f)
+	log.Printf("script is %v", script)
+	n := filepath.Join(dir, fmt.Sprintf("%d", generation))
+	f.Push(n)
+	saverom(f)
+	generation++
+	names := []string{n}
+	var xit bool
+	for !xit {
+		var victim *info
+		// pick a candidate to remove
+		// pick the LAST one we find.
+		// we suspect that later ones are more likely to
+		// depend on earlier ones.
+		for _, f := range files {
+			if _, ok := f.tags[keep]; ok {
+				continue
+			}
+			if _, ok := f.tags[remove]; ok {
+				continue
+			}
+			if v, ok := notouch[f.ftype]; ok && v {
+				f.tags[keep] = "notouch"
+				continue
+			}
+			victim = f
+		}
+		if victim == nil {
+			break
+		}
+		victim.tags[remove] = "cleaner"
+		n = filepath.Join(dir, fmt.Sprintf("%d", generation))
+		f.Push(n)
+		saverom(f)
+		generation++
+		out, err := exec.CommandContext(ctx, script, n).CombinedOutput()
+		if err != nil {
+			r.Undo()
+			delete(victim.tags, remove)
+			victim.tags[keep] = "cleaner"
+			e := fmt.Sprintf("%v", err)
+			if false && e != "exit status 2" {
+				f.Push(names)
+				f.Push(string(out))
+				f.Push(err)
+				return
+			}
+			continue
+		}
+		log.Printf("Removed %v", victim)
+		victim.tags[removed] = "cleaner"
+		names = append(names, n)
+		select {
+		case <-done:
+			xit = true
+		default:
+		}
+	}
+	f.Push(names)
+}
+
+// Find uses the string at TOS as an RE.
+// It returns with the []*info at TOS.
+func find(f forth.Forth) {
+	r := forth.String(f)
+	re := regexp.MustCompile(r)
+	var res []string
+	for _, vf := range files {
+		if !re.MatchString(vf.name) {
+			continue
+		}
+		res = append(res, vf.name)
+	}
+	f.Push(r)
+	f.Push(res)
+}
+
+func ix(f forth.Forth) {
+	r := ".*"
+	if len(f.Stack()) > 0 {
+		r = forth.String(f)
+	}
+	re := regexp.MustCompile(r)
+	var res []*info
+	for _, vf := range files {
+		if !re.MatchString(vf.name) {
+			continue
+		}
+		res = append(res, vf)
+	}
+	f.Push(res)
+}
+
+func main() {
+	f := forth.New()
+	for _, c := range commands {
+		f.Newop(c.c, c.f)
+	}
+	var b = make([]byte, 512)
+	flag.Parse()
+	// first process the args
+	s, err := forth.Eval(f, strings.Join(flag.Args(), " "))
+	// In the next u-root release we'll add a new type of eval
+	// that won't pop the stack but for now we have to simulate it.
+	if err != nil {
+		log.Printf("%v", err)
+	} else {
+		f.Push(s)
+	}
+	for {
+		fmt.Printf("%v", f.Stack())
+		fmt.Print("OK ")
+		n, err := os.Stdin.Read(b)
+		if err != nil {
+			if err != io.EOF {
+				log.Fatal(err)
+			}
+			// Silently exit on EOF. It's the unix way.
+			break
+		}
+		s, err := forth.Eval(f, string(b[:n]))
+		if err != nil {
+			fmt.Printf("%v\n", err)
+		}
+		if err == nil {
+			f.Push(s)
+		}
+	}
+}

--- a/pkg/visitors/remove.go
+++ b/pkg/visitors/remove.go
@@ -6,6 +6,7 @@ package visitors
 
 import (
 	"github.com/linuxboot/fiano/pkg/uefi"
+	"log"
 )
 
 // Remove all firmware files with the given GUID.
@@ -55,11 +56,13 @@ func (v *Remove) Visit(f uefi.Firmware) error {
 					} else {
 						f.Files = append(f.Files[:i], f.Files[i+1:]...)
 					}
+					log.Printf("Remove: %d files now", len(f.Files))
 
 					// Creates a stack of undoes in case there are multiple FVs.
 					prev := v.Undo
 					v.Undo = func() {
 						f.Files = originalList
+						log.Printf("Undo: %d files now", len(f.Files))
 						v.Undo = prev
 					}
 				}

--- a/vendor/github.com/u-root/u-root/pkg/forth/forth.go
+++ b/vendor/github.com/u-root/u-root/pkg/forth/forth.go
@@ -1,0 +1,321 @@
+// Copyright 2010-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package forth implements Forth parsing, which allows
+// programs to use forth-like syntax to manipulate a stack
+// of Cells.
+// It is designed for use by programs
+// needing to evaluate command-line arguments or simple
+// expressions to set program variables. It is designed
+// to map host names to numbers. We use it to
+// easily convert host names and IP addresses into
+// parameters.
+// The language
+// is a Forth-like postfix notation. Elements are
+// either commands or strings. Strings are
+// immediately pushed. Commands consume stack variables
+// and produce new ones.
+// Simple examples:
+// push hostname, strip alpha characters to produce a number. If your
+// hostname is sb47, top of stack will be left with 47.
+// hostname  hostbase
+// Get the hostbase, if it is 0 mod 20, return the hostbase / 20,
+// else return hostbase mod 20
+//
+// hostname hostbase dup 20 / swap 20 % dup ifelse
+//
+// At the end of the evaluation the stack should have one element
+// left; that element is popped and returned. It is an error (currently)
+// to return with a non-empty stack.
+// This package was used for real work at Sandia National Labs from 2010 to 2012 and possibly later.
+// Some of the use of error may seem a bit weird but the creation of this package predates the
+// creation of the error type (it was still an os thing back then).
+package forth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type (
+	// Op is an opcode type. It does not return an error value,
+	// instead using panic when parsing issues occur, to ease
+	// the programming annoyance of propagating errors up the
+	// stack (following common Go practice for parsers).
+	// If you write an op it can use panic as well.
+	// Lest you get upset about the use of panic, be aware
+	// I've talked to the folks in Go core about this and
+	// they feel it's fine for parsers.
+	Op func(f Forth)
+	// Cell is a stack element.
+	Cell interface{}
+
+	stack struct {
+		stack []Cell
+	}
+)
+
+var opmap = map[string]Op{
+	"+":        plus,
+	"-":        sub,
+	"*":        times,
+	"/":        div,
+	"%":        mod,
+	"swap":     swap,
+	"ifelse":   ifelse,
+	"hostname": hostname,
+	"hostbase": hostbase,
+	"strcat":   strcat,
+	"roundup":  roundup,
+	"dup":      dup,
+}
+
+// Forth is an interface used by the package. The interface
+// requires definition of Push, Pop, Length, Empty (convenience function
+// meaning Length is 0), Newop (insert a new or replacement operator),
+// and Reset (clear the stack, mainly diagnostic)
+type Forth interface {
+	Push(Cell)
+	Pop() Cell
+	Length() int
+	Empty() bool
+	Newop(string, Op)
+	Reset()
+	Stack() []Cell
+}
+
+// New creates a new stack
+func New() Forth {
+	f := new(stack)
+	return f
+}
+
+// Newop creates a new operation. We considered having
+// an opmap per stack but don't feel the package requires it
+func (f *stack) Newop(n string, op Op) {
+	opmap[n] = op
+}
+
+// Ops returns the operator map.
+func Ops() map[string]Op {
+	return opmap
+}
+
+// Reset resets the stack to empty
+func (f *stack) Reset() {
+	f.stack = f.stack[0:0]
+}
+
+// Return the stack
+func (f *stack) Stack() []Cell {
+	return f.stack
+}
+
+// Push pushes the interface{} on the stack.
+func (f *stack) Push(c Cell) {
+	f.stack = append(f.stack, c)
+	//fmt.Printf("push: %v: stack: %v\n", s, f.stack)
+}
+
+// Pop pops the stack. If the stack is Empty Pop will panic.
+// Eval recovers() the panic.
+func (f *stack) Pop() (ret Cell) {
+
+	if len(f.stack) < 1 {
+		panic(errors.New("Empty stack"))
+	}
+	ret = f.stack[len(f.stack)-1]
+	f.stack = f.stack[0 : len(f.stack)-1]
+	//fmt.Printf("Pop: %v stack %v\n", ret, f.stack)
+	return ret
+}
+
+// Length returns the stack length.
+func (f *stack) Length() int {
+	return len(f.stack)
+}
+
+// Empty is a convenience function synonymous with Length == 0
+func (f *stack) Empty() bool {
+	return len(f.stack) == 0
+}
+
+// errRecover converts panics to errstr iff it is an os.Error, panics
+// otherwise.
+func errRecover(errp *error) {
+	e := recover()
+	if e != nil {
+		if _, ok := e.(runtime.Error); ok {
+			panic(e)
+		}
+		*errp = fmt.Errorf("%v", e)
+	}
+}
+
+/* iEval takes a Forth and strings and splits the string on space
+ * characters, pushing each element on the stack or invoking the
+ * operator if it is found in the opmap.
+ */
+func iEval(f Forth, s string) {
+	// TODO: create a separator list based on isspace and all the
+	// non alpha numberic characters in the opmap.
+	for _, val := range strings.Fields(s) {
+		//fmt.Printf("eval %s stack %v", val, f.Stack())
+		fun := opmap[val]
+		if fun != nil {
+			//fmt.Printf("Eval ...:")
+			fun(f)
+			//fmt.Printf("Stack now %v", f.Stack())
+		} else {
+			f.Push(val)
+			//fmt.Printf("push %s, stack %v", val, f.Stack())
+		}
+	}
+	return
+}
+
+// Eval takes a Forth and strings and splits the string on space
+// characters, pushing each element on the stack or invoking the
+// operator if it is found in the opmap. It returns TOS when it is done.
+// it is an error to leave the stack non-Empty.
+//
+func Eval(f Forth, s string) (ret Cell, err error) {
+	defer errRecover(&err)
+	iEval(f, s)
+	ret = f.Pop()
+	return
+
+}
+
+// String returns the Top Of Stack if it is a string
+// or panics.
+func String(f Forth) string {
+	c := f.Pop()
+	switch s := c.(type) {
+	case string:
+		return s
+	default:
+		panic(fmt.Sprintf("Can't convert %v to a string", c))
+	}
+}
+
+// toInt converts to int64.
+func toInt(f Forth) int64 {
+	c := f.Pop()
+	switch s := c.(type) {
+	case string:
+		i, err := strconv.ParseInt(s, 0, 64)
+		if err != nil {
+			panic(err)
+		}
+		return i
+	case int64:
+		return s
+	default:
+		panic(fmt.Sprintf("NaN: %T", c))
+	}
+}
+
+func plus(f Forth) {
+	x := toInt(f)
+	y := toInt(f)
+	z := x + y
+	f.Push(strconv.FormatInt(z, 10))
+}
+
+func times(f Forth) {
+	x := toInt(f)
+	y := toInt(f)
+	z := x * y
+	f.Push(strconv.FormatInt(z, 10))
+}
+
+func sub(f Forth) {
+	x := toInt(f)
+	y := toInt(f)
+	z := y - x
+	f.Push(strconv.FormatInt(z, 10))
+}
+
+func div(f Forth) {
+	x := toInt(f)
+	y := toInt(f)
+	z := y / x
+	f.Push(strconv.FormatInt(z, 10))
+}
+
+func mod(f Forth) {
+	x := toInt(f)
+	y := toInt(f)
+	z := y % x
+	f.Push(strconv.FormatInt(z, 10))
+}
+
+func roundup(f Forth) {
+	rnd := toInt(f)
+	v := toInt(f)
+	v = ((v + rnd - 1) / rnd) * rnd
+	f.Push(strconv.FormatInt(v, 10))
+}
+
+func swap(f Forth) {
+	x := f.Pop()
+	y := f.Pop()
+	f.Push(x)
+	f.Push(y)
+}
+
+func strcat(f Forth) {
+	x := String(f)
+	y := String(f)
+	f.Push(y + x)
+}
+
+func dup(f Forth) {
+	x := f.Pop()
+	f.Push(x)
+	f.Push(x)
+}
+
+func ifelse(f Forth) {
+	x := toInt(f)
+	y := f.Pop()
+	z := f.Pop()
+	if x != 0 {
+		f.Push(y)
+	} else {
+		f.Push(z)
+	}
+}
+
+func hostname(f Forth) {
+	h, err := os.Hostname()
+	if err != nil {
+		panic("No hostname")
+	}
+	f.Push(h)
+}
+
+func hostbase(f Forth) {
+	host := String(f)
+	f.Push(strings.TrimLeft(host, "abcdefghijklmnopqrstuvwxyz -"))
+}
+
+// NewWord allows for definition of new operators from strings.
+// For example, should you wish to create a word which adds a number
+// to itself twice, you can call:
+// NewWord(f, "d3d", "dup dup + +")
+// which does two dups, and two adds.
+func NewWord(f Forth, name, command string) {
+	newword := func(f Forth) {
+		iEval(f, command)
+		return
+	}
+	opmap[name] = newword
+	return
+}

--- a/vendor/github.com/ulikunitz/xz/lzma/encoder.go
+++ b/vendor/github.com/ulikunitz/xz/lzma/encoder.go
@@ -11,7 +11,7 @@ import (
 
 // opLenMargin provides the upper limit of the number of bytes required
 // to encode a single operation.
-const opLenMargin = 10
+const opLenMargin = 16
 
 // compressFlags control the compression process.
 type compressFlags uint32


### PR DESCRIPTION
This is a forth utk.

I think doing it as a new program has some benefits.
I notice we're wiring some assumptions into utk package for the
utk program, and it really becomes apparent when you try to
write a second program. This way, we can make sure the utk package
will work for more than just utk.

I no longer have to annoy Gan about the forth interface, and
I no longer have to annoy Ryan with commands I want :-)

This is a trivial interactive forth program, not really
done maybe, that lets me do a bit more messing about
a bit more easily than utk.

The model is that one can read in an fv, see things, mess
with things and, when done, push things out. You can make
decisions about what to remove, and then undo those
decisions, and only commmit when you type 'go'.

You can tag things with arbitrary tags and arbitrary text,
said text can even be output of other commands.

Two tags, r and k, have meaning to futk; r means 'removing when
writing firmware volume', and k means 'add to blacklist for
dxecleaner'.

The go command creates a new image. You can think of it as a commit.
Again, if you have tagged any DXEs as k, it writes out a blacklist suitable
(we hope) for a dxeclean pass; things tagged r are removed.

Here's an example session:

rminnich@uroot:~/go/src/github.com/linuxboot/fiano/cmds/futk$ ./futk 7106V100.ROM fv
2018/11/21 09:14:29 Found 413 things
413
OK Tcp|Pxe|Udp ix r r tag
[6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B:EFI_FV_FILETYPE_DRIVER:Udp4Dxe D912C7BC-F098-4367-92BA-E911083C7B0E:EFI_FV_FILETYPE_DRIVER:Udp6Dxe B95E9FDA-26DE-48D2-8807-1F9107AC5E3A:EFI_FV_FILETYPE_DRIVER:UefiPxeBcDxe 1A7E4468-2F55-4A56-903C-01265EB7622B:EFI_FV_FILETYPE_DRIVER:TcpDxe]
OK Tcp|Pxe|Udp ix status
1A7E4468-2F55-4A56-903C-01265EB7622B:EFI_FV_FILETYPE_DRIVER:TcpDxe: res map[r:r]
6D6963AB-906D-4A65-A7CA-BD40E5D6AF2B:EFI_FV_FILETYPE_DRIVER:Udp4Dxe: res map[r:r]
D912C7BC-F098-4367-92BA-E911083C7B0E:EFI_FV_FILETYPE_DRIVER:Udp6Dxe: res map[r:r]
B95E9FDA-26DE-48D2-8807-1F9107AC5E3A:EFI_FV_FILETYPE_DRIVER:UefiPxeBcDxe: res map[r:r]

OK bzImage.uroot splat
[7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell]
OK go
[/tmp/futkblacklist753009682 /tmp/futkrom522877513]
OK

OK is the prompt.
In Forth fashion, OK is printed even if things are not, strictly speaking, OK.
On an old Sun, flames could be shooting out the top, and the firmware prompt
would still be
OK

Breaking this down:
Tcp|Pxe|Udp ix
will push an array on TOS of the things it finds. The
r r tag
uses that array and tags it with an r tag, set in a map; you can use any value
for the r tag you want. tag value is first, name second and,
note, the value can be a forth expression:
OK APPLI ix 2 2 + r tag
[7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell]
OK APPLI ix status
7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell: res map[r:4]

When the go command is run, things tagged with r are removed. The value of the r tag
is of no consequence.

Some DXEs you want to keep; you can do a similar thing with ix and tag
them as k.

GUIDs of DXEs tagged with k are written to the blacklist file.

The splat command does a transplat on the selected SET OF files that match .*Shell.*
So, in this case, we transplat these with bzImage.uroot. It shows us
the identities of the file(s) it replaced. It also adds a tag to the file, which is
ignored by the go command, but useful to humans:
OK Shell ix status
7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell: res map[replaced:shell]

Note that the name includes GUID, type, and name, so you can do stuff like this:
OK APPLICATION ix status
7C04A583-9E3E-4F1C-AD65-E05268D0B4D1:EFI_FV_FILETYPE_APPLICATION:FullShell: res map[]

i.e. show all applications.

Obviously there's lots that can be done but I'm already finding this easier to use than utk.

I think the combination of simple interactivity and the ability to backout and or finely add changes helps.

The utk visitor pattern made this all so incredibly easy, FYI.

If you keep misreading futk for Something Else, well, I think
it's more a comment on you than the name of the program :-)
So There! :-)

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>