### PR TITLE
remove visitor: don't call all prev functions, just do one and pop stack

### DIFF
--- a/pkg/visitors/remove.go
+++ b/pkg/visitors/remove.go
@@ -60,9 +60,7 @@ func (v *Remove) Visit(f uefi.Firmware) error {
 					prev := v.Undo
 					v.Undo = func() {
 						f.Files = originalList
-						if prev != nil {
-							prev()
-						}
+						v.Undo = prev
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Ronald G. Minnich <rminnich@google.com>