### PR TITLE
Fix remove_dxes_except corner cases

### DIFF
--- a/pkg/visitors/find.go
+++ b/pkg/visitors/find.go
@@ -109,11 +109,11 @@ func FindFileTypePredicate(t uefi.FVFileType) FindPredicate {
 
 // FindFilePredicate is a generic predicate for searching files and UI sections only.
 func FindFilePredicate(r string) (func(f uefi.Firmware) bool, error) {
-	searchRE, err := regexp.Compile("^" + r + "$")
+	searchRE, err := regexp.Compile("^(" + r + ")$")
 	if err != nil {
 		return nil, err
 	}
-	ciRE, err := regexp.Compile("^(?i)" + r + "$")
+	ciRE, err := regexp.Compile("^(?i)(" + r + ")$")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The parseBlackList function create a regex with several string option,
FindFilePredicate encapsulate it to match whole word only but we have
to take care of the blacklist case where the regex string include '|'.

Signed-off-by: Julien Viard de Galbert <julien.viard-de-galbert@itrenew.com>