### PR TITLE
ME partitions

### DIFF
--- a/pkg/uefi/flash.go
+++ b/pkg/uefi/flash.go
@@ -20,8 +20,6 @@ var (
 const (
 	// FlashDescriptorLength represents the size of the descriptor region.
 	FlashDescriptorLength = 0x1000
-	// FlashSignatureLength represents the size of the flash signature
-	FlashSignatureLength = 4
 )
 
 // FlashDescriptor is the main structure that represents an Intel Flash Descriptor.
@@ -41,13 +39,13 @@ type FlashDescriptor struct {
 
 // FindSignature searches for an Intel flash signature.
 func FindSignature(buf []byte) (int, error) {
-	if bytes.Equal(buf[16:16+FlashSignatureLength], FlashSignature) {
+	if bytes.Equal(buf[16:16+len(FlashSignature)], FlashSignature) {
 		// 16 + 4 since the descriptor starts after the signature
 		return 20, nil
 	}
-	if bytes.Equal(buf[:FlashSignatureLength], FlashSignature) {
+	if bytes.Equal(buf[:len(FlashSignature)], FlashSignature) {
 		// + 4 since the descriptor starts after the signature
-		return FlashSignatureLength, nil
+		return len(FlashSignature), nil
 	}
 	return -1, fmt.Errorf("Flash signature not found: first 20 bytes are:\n%s",
 		hex.Dump(buf[:20]))

--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -4,8 +4,161 @@
 
 package uefi
 
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"log"
+)
+
+// ME Partition parsing, the goal is to spot a padding in the ME Region
+// after the ME partitions so that this region can be shrunk in the IFD.
+//
+// ME partition informations from http://me.bios.io/ME_blob_format
+
+// MEFTPSignature is the sequence of bytes that an ME Flash Partition
+// Table is expected to start with.
+var (
+	MEFTPSignature = []byte{0x24, 0x46, 0x50, 0x54}
+)
+
+const (
+	// MEFTPSignatureLength represents the size of the ME FTP signature
+	MEFTPSignatureLength = 4
+	// MEPartitionTableEntryLength is the size of a partition table entry
+	MEPartitionTableEntryLength = 32
+)
+
+// MEFPT is the main structure that represents an ME Flash Partition Table.
+type MEFPT struct {
+	// Holds the raw buffer
+	buf []byte
+
+	PartitionCount    uint32
+	PartitionMapStart int
+	Entries           []MePartitionEntry
+	//Metadata for extraction and recovery
+	ExtractPath string
+}
+
+// MePartitionEntry is an entry in FTP
+type MePartitionEntry struct {
+	Name     MeName
+	Owner    [4]byte
+	Offset   uint32
+	Length   uint32
+	Reserved [4]uint32
+}
+
+// MeName represent 4 bytes with JSON string support
+// OK this is probably overkill!
+type MeName [4]byte
+
+// MarshalText converts MeName to a byte range (for JSON)
+func (n MeName) MarshalText() ([]byte, error) {
+	e := len(n)
+	for e > 0 && n[e-1] == 0 {
+		e--
+	}
+	return n[:e], nil
+}
+
+// UnmarshalText converts a byte range to MeName (for JSON)
+func (n *MeName) UnmarshalText(b []byte) error {
+	for i := range n[:] {
+		var v byte
+		if i < len(b) {
+			v = b[i]
+		}
+		n[i] = v
+	}
+	return nil
+}
+
+func (n MeName) String() string {
+	b, _ := n.MarshalText()
+	return string(b)
+}
+
+// FindMESignature searches for an Intel ME FTP signature
+func FindMESignature(buf []byte) (int, error) {
+	if bytes.Equal(buf[16:16+MEFTPSignatureLength], MEFTPSignature) {
+		// 16 + 4 since the descriptor starts after the signature
+		return 20, nil
+	}
+	if bytes.Equal(buf[:MEFTPSignatureLength], MEFTPSignature) {
+		// + 4 since the descriptor starts after the signature
+		return MEFTPSignatureLength, nil
+	}
+	return -1, fmt.Errorf("ME Flash Partition Table signature not found: first 20 bytes are:\n%s",
+		hex.Dump(buf[:20]))
+}
+
+// Buf returns the buffer.
+// Used mostly for things interacting with the Firmware interface.
+func (fp *MEFPT) Buf() []byte {
+	return fp.buf
+}
+
+// SetBuf sets the buffer.
+// Used mostly for things interacting with the Firmware interface.
+func (fp *MEFPT) SetBuf(buf []byte) {
+	fp.buf = buf
+}
+
+// Apply calls the visitor on the MEFPT.
+func (fp *MEFPT) Apply(v Visitor) error {
+	return v.Visit(fp)
+}
+
+// ApplyChildren calls the visitor on each child node of MEFPT.
+func (fp *MEFPT) ApplyChildren(v Visitor) error {
+	return nil
+}
+
+// NewMEFPT tries to create a MEFPT
+func NewMEFPT(buf []byte) (*MEFPT, error) {
+	o, err := FindMESignature(buf)
+	if err != nil {
+		return nil, err
+	}
+	if len(buf) < o+28 {
+		return nil, fmt.Errorf("ME section (%#x) too small for ME Flash Partition Table (%#x)", len(buf), o+28)
+	}
+	fp := &MEFPT{PartitionMapStart: o + 28}
+	r := bytes.NewReader(buf[o:])
+	if err := binary.Read(r, binary.LittleEndian, &fp.PartitionCount); err != nil {
+		return nil, err
+	}
+	l := fp.PartitionMapStart + MEPartitionTableEntryLength*int(fp.PartitionCount)
+	if len(buf) < l {
+		return nil, fmt.Errorf("ME section (%#x) too small for %d entries in ME Flash Partition Table (%#x)", len(buf), fp.PartitionCount, l)
+	}
+
+	fp.buf = make([]byte, l)
+	copy(fp.buf, buf[:l])
+	if err := fp.parsePartitions(); err != nil {
+		return nil, err
+	}
+	return fp, nil
+}
+
+func (fp *MEFPT) parsePartitions() error {
+	r := bytes.NewReader(fp.buf[fp.PartitionMapStart:])
+	for i := 0; i < int(fp.PartitionCount); i++ {
+		var entry MePartitionEntry
+		if err := binary.Read(r, binary.LittleEndian, &entry); err != nil {
+			return err
+		}
+		fp.Entries = append(fp.Entries, entry)
+	}
+	return nil
+}
+
 // MERegion implements Region for a raw chunk of bytes in the firmware image.
 type MERegion struct {
+	FPT *MEFPT
 	// holds the raw data
 	buf []byte
 	// Metadata for extraction and recovery
@@ -31,6 +184,12 @@ func NewMERegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error)
 	rr := &MERegion{FRegion: r, RegionType: rt}
 	rr.buf = make([]byte, len(buf))
 	copy(rr.buf, buf)
+	fp, err := NewMEFPT(buf)
+	if err != nil {
+		log.Printf("error parsing ME Flash Partition Table: %v", err)
+		return rr, nil
+	}
+	rr.FPT = fp
 	return rr, nil
 }
 

--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -1,0 +1,62 @@
+// Copyright 2018 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uefi
+
+// MERegion implements Region for a raw chunk of bytes in the firmware image.
+type MERegion struct {
+	// holds the raw data
+	buf []byte
+	// Metadata for extraction and recovery
+	ExtractPath string
+	// This is a pointer to the FlashRegion struct laid out in the ifd.
+	FRegion *FlashRegion
+	// Region Type as per the IFD
+	RegionType FlashRegionType
+}
+
+// SetFlashRegion sets the flash region.
+func (rr *MERegion) SetFlashRegion(fr *FlashRegion) {
+	rr.FRegion = fr
+}
+
+// FlashRegion gets the flash region.
+func (rr *MERegion) FlashRegion() (fr *FlashRegion) {
+	return rr.FRegion
+}
+
+// NewMERegion creates a new region.
+func NewMERegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error) {
+	rr := &MERegion{FRegion: r, RegionType: rt}
+	rr.buf = make([]byte, len(buf))
+	copy(rr.buf, buf)
+	return rr, nil
+}
+
+// Type returns the flash region type.
+func (rr *MERegion) Type() FlashRegionType {
+	return RegionTypeME
+}
+
+// Buf returns the buffer.
+// Used mostly for things interacting with the Firmware interface.
+func (rr *MERegion) Buf() []byte {
+	return rr.buf
+}
+
+// SetBuf sets the buffer.
+// Used mostly for things interacting with the Firmware interface.
+func (rr *MERegion) SetBuf(buf []byte) {
+	rr.buf = buf
+}
+
+// Apply calls the visitor on the MERegion.
+func (rr *MERegion) Apply(v Visitor) error {
+	return v.Visit(rr)
+}
+
+// ApplyChildren calls the visitor on each child node of MERegion.
+func (rr *MERegion) ApplyChildren(v Visitor) error {
+	return nil
+}

--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -227,5 +227,12 @@ func (rr *MERegion) Apply(v Visitor) error {
 
 // ApplyChildren calls the visitor on each child node of MERegion.
 func (rr *MERegion) ApplyChildren(v Visitor) error {
+	if rr.FPT == nil {
+		return nil
+	}
+	if err := rr.FPT.Apply(v); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -167,6 +167,8 @@ type MERegion struct {
 	FRegion *FlashRegion
 	// Region Type as per the IFD
 	RegionType FlashRegionType
+	// Computed free space after parsing the partition table
+	FreeSpaceOffset uint64
 }
 
 // SetFlashRegion sets the flash region.
@@ -190,6 +192,14 @@ func NewMERegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error)
 		return rr, nil
 	}
 	rr.FPT = fp
+	// Compute FreeSpaceOffset
+	for _, p := range fp.Entries {
+		endOffset := uint64(p.Offset) + uint64(p.Length)
+		if endOffset > rr.FreeSpaceOffset {
+			rr.FreeSpaceOffset = endOffset
+		}
+	}
+
 	return rr, nil
 }
 

--- a/pkg/uefi/meregion_test.go
+++ b/pkg/uefi/meregion_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uefi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMEName_MarshalText(t *testing.T) {
+	var tests = []struct {
+		name string
+		me   MEName
+	}{
+		{"NAME", MEName{'N', 'A', 'M', 'E'}},
+		{"NAM", MEName{'N', 'A', 'M', 0}},
+		{"NA", MEName{'N', 'A', 0, 0}},
+		{"N", MEName{'N', 0, 0, 0}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := test.me.MarshalText()
+			if err != nil {
+				t.Errorf("Unexpected error %v", err)
+			}
+			if string(b) != test.name {
+				t.Errorf("error got %q want %q", b, test.name)
+			}
+		})
+	}
+}
+
+func TestMEName_UnmarshalText(t *testing.T) {
+	var tests = []struct {
+		name string
+		me   MEName
+		msg  string
+	}{
+		{"NAME", MEName{'N', 'A', 'M', 'E'}, ""},
+		{"NAM", MEName{'N', 'A', 'M', 0}, ""},
+		{"NA", MEName{'N', 'A', 0, 0}, ""},
+		{"N", MEName{'N', 0, 0, 0}, ""},
+		{"NAME1", MEName{'N', 'A', 'M', 'E'}, "Can’t unmarshal \"NAME1\" to MEName, 5 > 4"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			me := MEName{'F', 'U', 'L', 'L'}
+			err := me.UnmarshalText([]byte(test.name))
+			if err == nil && test.msg != "" {
+				t.Errorf("Error was not returned, expected %v", test.msg)
+			} else if err != nil && err.Error() != test.msg {
+				t.Errorf("Mismatched Error returned, expected \n%v\n got \n%v\n", test.msg, err.Error())
+			} else if !reflect.DeepEqual(me, test.me) {
+				t.Errorf("error got %q want %q", me, test.me)
+			}
+
+		})
+	}
+}

--- a/pkg/uefi/region.go
+++ b/pkg/uefi/region.go
@@ -96,7 +96,7 @@ func (r *FlashRegion) EndOffset() uint32 {
 
 var regionConstructors = map[FlashRegionType]func(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error){
 	RegionTypeBIOS:      NewBIOSRegion,
-	RegionTypeME:        NewRawRegion,
+	RegionTypeME:        NewMERegion,
 	RegionTypeGBE:       NewRawRegion,
 	RegionTypePD:        NewRawRegion,
 	RegionTypeDevExp1:   NewRawRegion,

--- a/pkg/uefi/uefi.go
+++ b/pkg/uefi/uefi.go
@@ -110,6 +110,7 @@ var firmwareTypes = map[string]func() Firmware{
 	"*uefi.FirmwareVolume":  func() Firmware { return &FirmwareVolume{} },
 	"*uefi.FlashDescriptor": func() Firmware { return &FlashDescriptor{} },
 	"*uefi.FlashImage":      func() Firmware { return &FlashImage{} },
+	"*uefi.MERegion":        func() Firmware { return &MERegion{} },
 	"*uefi.RawRegion":       func() Firmware { return &RawRegion{} },
 	"*uefi.Section":         func() Firmware { return &Section{} },
 }

--- a/pkg/visitors/extract.go
+++ b/pkg/visitors/extract.go
@@ -148,6 +148,10 @@ func (v *Extract) Visit(f uefi.Firmware) error {
 			f.ExtractPath, err = v2.extractBinary(f.Buf(), "biosregion.bin")
 		}
 
+	case *uefi.MERegion:
+		v2.DirPath = filepath.Join(v.DirPath, "me")
+		f.ExtractPath, err = v2.extractBinary(f.Buf(), "meregion.bin")
+
 	case *uefi.RawRegion:
 		v2.DirPath = filepath.Join(v.DirPath, f.Type().String())
 		f.ExtractPath, err = v2.extractBinary(f.Buf(), fmt.Sprintf("%#x.bin", f.FlashRegion().BaseOffset()))

--- a/pkg/visitors/parsedir.go
+++ b/pkg/visitors/parsedir.go
@@ -77,6 +77,9 @@ func (v *ParseDir) Visit(f uefi.Firmware) error {
 	case *uefi.BIOSRegion:
 		fBuf, err = v.readBuf(f.ExtractPath)
 
+	case *uefi.MERegion:
+		fBuf, err = v.readBuf(f.ExtractPath)
+
 	case *uefi.RawRegion:
 		fBuf, err = v.readBuf(f.ExtractPath)
 

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -59,6 +59,11 @@ func (v *Table) Visit(f uefi.Firmware) error {
 		return v.printFirmware(f, "NVAR Store", "", "", v.curOffset, v.curOffset)
 	case *uefi.NVar:
 		return v.printFirmware(f, "NVAR", f.GUID.String(), f, v.curOffset, v.curOffset+uint64(f.DataOffset))
+	case *uefi.MERegion:
+		if f.FRegion != nil {
+			offset = uint64(f.FRegion.BaseOffset())
+		}
+		return v.printFirmware(f, "ME", "", "", offset, offset)
 	case *uefi.RawRegion:
 		if f.FRegion != nil {
 			offset = uint64(f.FRegion.BaseOffset())

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -64,6 +64,8 @@ func (v *Table) Visit(f uefi.Firmware) error {
 			offset = uint64(f.FRegion.BaseOffset())
 		}
 		return v.printFirmware(f, "ME", "", "", offset, offset)
+	case *uefi.MEFPT:
+		return v.printFirmware(f, "$FPT", "", "", v.offset, 0)
 	case *uefi.RawRegion:
 		if f.FRegion != nil {
 			offset = uint64(f.FRegion.BaseOffset())
@@ -124,6 +126,11 @@ func (v *Table) printFirmware(f uefi.Firmware, node, name, typez interface{}, of
 		v2.printRow(&v2, "GUIDStore", "", fmt.Sprintf("%d GUID", len(f.GUIDStore)), offset+f.GUIDStoreOffset, f.Length-f.GUIDStoreOffset)
 	case *uefi.MERegion:
 		v2.printRow(&v2, "Free", "", "", offset+f.FreeSpaceOffset, length-f.FreeSpaceOffset)
+	case *uefi.MEFPT:
+		// MERegion is not entered, simply print the $FPT content here
+		for _, p := range f.Entries {
+			v2.printRow(&v2, p.Name, "", "", offset+uint64(p.Offset), uint64(p.Length))
+		}
 	case *uefi.File:
 		// Align
 		v.curOffset = uefi.Align8(v.curOffset)

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -122,6 +122,8 @@ func (v *Table) printFirmware(f uefi.Firmware, node, name, typez interface{}, of
 		// Print free space and GUID store
 		v2.printRow(&v2, "Free", "", "", offset+f.FreeSpaceOffset, f.GUIDStoreOffset-f.FreeSpaceOffset)
 		v2.printRow(&v2, "GUIDStore", "", fmt.Sprintf("%d GUID", len(f.GUIDStore)), offset+f.GUIDStoreOffset, f.Length-f.GUIDStoreOffset)
+	case *uefi.MERegion:
+		v2.printRow(&v2, "Free", "", "", offset+f.FreeSpaceOffset, length-f.FreeSpaceOffset)
 	case *uefi.File:
 		// Align
 		v.curOffset = uefi.Align8(v.curOffset)

--- a/pkg/visitors/validate.go
+++ b/pkg/visitors/validate.go
@@ -233,6 +233,14 @@ func (v *Validate) Visit(f uefi.Firmware) error {
 		}
 		return nil // We already traversed the children manually.
 
+	case *uefi.MERegion:
+		if f.FlashRegion() == nil {
+			v.Errors = append(v.Errors, errors.New("Region position is nil"))
+		}
+		if !f.FlashRegion().Valid() {
+			v.Errors = append(v.Errors, fmt.Errorf("Region is not valid, region was %v", *f.FlashRegion()))
+		}
+
 	case *uefi.RawRegion:
 		if f.FlashRegion() == nil {
 			v.Errors = append(v.Errors, errors.New("Region position is nil"))


### PR DESCRIPTION
ME Partition parsing, the goal is to spot a padding in the ME Region after the ME partitions so that this region can be shrunk in the IFD.

ME partition informations from http://me.bios.io/ME_blob_format
