### PR TITLE
visitors/assemble: regenerate IFD from the parsed content

### DIFF
--- a/pkg/uefi/flash.go
+++ b/pkg/uefi/flash.go
@@ -242,8 +242,8 @@ func NewFlashImage(buf []byte) (*FlashImage, error) {
 		return nil, err
 	}
 
-	// FlashRegions
-	frs := f.IFD.Region.FlashRegions
+	// FlashRegions is an array, make a slice to keep reference to it's content
+	frs := f.IFD.Region.FlashRegions[:]
 
 	// BIOS region has to be valid
 	if !frs[RegionTypeBIOS].Valid() {

--- a/pkg/uefi/flashdescriptormap.go
+++ b/pkg/uefi/flashdescriptormap.go
@@ -14,6 +14,9 @@ const (
 	// FlashDescriptorMapMaxBase is the maximum base address for a flash descriptor
 	// region
 	FlashDescriptorMapMaxBase = 0xe0
+
+	// FlashDescriptorMapSize is the size in byte of the FlashDescriptorMap
+	FlashDescriptorMapSize = 16
 )
 
 // FlashDescriptorMap represent an Intel flash descriptor. This object provides

--- a/pkg/visitors/tightenme.go
+++ b/pkg/visitors/tightenme.go
@@ -101,10 +101,6 @@ func (v *TightenME) process() error {
 		return fmt.Errorf("Could not create BIOS Padding: %v", err)
 	}
 	v.br.Elements = append([]*uefi.TypedFirmware{uefi.MakeTyped(bp)}, v.br.Elements...)
-	// Update IFD
-	// I thought regions had references to the IFD... but it seams not so:
-	v.fd.Region.FlashRegions[uefi.RegionTypeBIOS] = *v.br.FRegion
-	v.fd.Region.FlashRegions[uefi.RegionTypeME] = *v.mer.FRegion
 	// Assemble will regenerate IFD so regions will be updated in the image
 
 	return nil

--- a/pkg/visitors/tightenme.go
+++ b/pkg/visitors/tightenme.go
@@ -5,8 +5,6 @@
 package visitors
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"log"
 
@@ -107,17 +105,7 @@ func (v *TightenME) process() error {
 	// I thought regions had references to the IFD... but it seams not so:
 	v.fd.Region.FlashRegions[uefi.RegionTypeBIOS] = *v.br.FRegion
 	v.fd.Region.FlashRegions[uefi.RegionTypeME] = *v.mer.FRegion
-	// Assemble is not regenerating IFD so update regions here
-	// TODO: remove this and fix Assemble
-	regions := new(bytes.Buffer)
-	err = binary.Write(regions, binary.LittleEndian, v.fd.Region)
-	if err != nil {
-		return fmt.Errorf("unable to construct binary region of IFD: got %v", err)
-	}
-
-	buf = v.fd.Buf()
-	copy(buf[v.fd.RegionStart:v.fd.RegionStart+uint(uefi.FlashRegionSectionSize)], regions.Bytes())
-	v.fd.SetBuf(buf)
+	// Assemble will regenerate IFD so regions will be updated in the image
 
 	return nil
 }


### PR DESCRIPTION
Note: The rest of the sector is kept in place

__The second commit fix the fact that BIOS/ME Regions `FRegion` was not pointing to the ones in the IFD as intended.__
