### PR TITLE
Fv table details

### DIFF
--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -139,6 +139,14 @@ func (fv *FirmwareVolume) GetErasePolarity() uint8 {
 	return 0
 }
 
+// String creates a string representation for the firmware volume.
+func (fv FirmwareVolume) String() string {
+	if fv.ExtHeaderOffset != 0 {
+		return fv.FVName.String()
+	}
+	return fv.FileSystemGUID.String()
+}
+
 func fillFFs(b []byte) {
 	for i := range b {
 		b[i] = 0xFF

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -96,7 +96,7 @@ type FirmwareVolume struct {
 
 	// Variables not in the binary for us to keep track of stuff/print
 	DataOffset  uint64
-	fvType      string
+	FVType      string `json:"-"`
 	buf         []byte
 	FVOffset    uint64 // Byte offset from start of BIOS region.
 	ExtractPath string
@@ -239,7 +239,7 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	// TODO: handle alignment field in header.
 	fv.DataOffset = Align8(fv.DataOffset)
 
-	fv.fvType = FVGUIDs[fv.FileSystemGUID]
+	fv.FVType = FVGUIDs[fv.FileSystemGUID]
 	fv.FVOffset = fvOffset
 
 	// copy out the buffer.
@@ -252,7 +252,7 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	// Start from the end of the fv header.
 	// Test if the fv type is supported.
 	if _, ok := supportedFVs[fv.FileSystemGUID]; !ok {
-		log.Printf("warning unsupported fv type %v,%v not parsing it", fv.FileSystemGUID.String(), fv.fvType)
+		log.Printf("warning unsupported fv type %v,%v not parsing it", fv.FileSystemGUID.String(), fv.FVType)
 		return &fv, nil
 	}
 	lh := fv.Length - FileHeaderMinLength

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -39,7 +39,7 @@ func (v *Table) Visit(f uefi.Firmware) error {
 		}
 		return v.printFirmware(f, "Image", "", "", 0, 0)
 	case *uefi.FirmwareVolume:
-		return v.printFirmware(f, "FV", f.FileSystemGUID.String(), f.FVType, v.offset+f.FVOffset, v.offset+f.FVOffset+f.DataOffset)
+		return v.printFirmware(f, "FV", f.String(), f.FVType, v.offset+f.FVOffset, v.offset+f.FVOffset+f.DataOffset)
 	case *uefi.File:
 		// TODO: make name part of the file node
 		return v.printFirmware(f, "File", f.Header.GUID.String(), f.Header.Type, v.curOffset, v.curOffset+f.DataOffset)

--- a/pkg/visitors/table.go
+++ b/pkg/visitors/table.go
@@ -39,7 +39,7 @@ func (v *Table) Visit(f uefi.Firmware) error {
 		}
 		return v.printFirmware(f, "Image", "", "", 0, 0)
 	case *uefi.FirmwareVolume:
-		return v.printFirmware(f, "FV", f.FileSystemGUID.String(), "", v.offset+f.FVOffset, v.offset+f.FVOffset+f.DataOffset)
+		return v.printFirmware(f, "FV", f.FileSystemGUID.String(), f.FVType, v.offset+f.FVOffset, v.offset+f.FVOffset+f.DataOffset)
 	case *uefi.File:
 		// TODO: make name part of the file node
 		return v.printFirmware(f, "File", f.Header.GUID.String(), f.Header.Type, v.curOffset, v.curOffset+f.DataOffset)


### PR DESCRIPTION
Display FVName GUID (from ext header) instead of FV type GUID if available.
Also display the decoded FV type in the type column.