### PR TITLE
uefi: Do not copy if not necessary

### DIFF
--- a/pkg/uefi/biosregion.go
+++ b/pkg/uefi/biosregion.go
@@ -84,9 +84,7 @@ func NewBIOSRegion(buf []byte, r *FlashRegion, _ FlashRegionType) (Region, error
 		RegionType: RegionTypeBIOS}
 	var absOffset uint64
 
-	// Copy the buffer
-	br.buf = make([]byte, len(buf))
-	copy(br.buf, buf)
+	br.buf = buf
 
 	for {
 		offset := FindFirmwareVolumeOffset(buf)

--- a/pkg/uefi/file.go
+++ b/pkg/uefi/file.go
@@ -416,10 +416,8 @@ func NewFile(buf []byte) (*File, error) {
 		return nil, fmt.Errorf("File size too big! File with GUID: %v has length %v, but is only %v bytes big",
 			f.Header.GUID, f.Header.ExtendedSize, buflen)
 	}
-	// Copy out the buffer.
-	newBuf := buf[:f.Header.ExtendedSize]
-	f.buf = make([]byte, f.Header.ExtendedSize)
-	copy(f.buf, newBuf)
+
+	f.buf = buf[:f.Header.ExtendedSize]
 
 	// Special case for NVAR Store stored in raw file
 	if f.Header.Type == FVFileTypeRaw && f.Header.GUID == *NVAR {

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -259,10 +259,7 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	fv.FVType = FVGUIDs[fv.FileSystemGUID]
 	fv.FVOffset = fvOffset
 
-	// copy out the buffer.
-	newBuf := data[:fv.Length]
-	fv.buf = make([]byte, fv.Length)
-	copy(fv.buf, newBuf)
+	fv.buf = data[:fv.Length]
 
 	// Parse the files.
 	// TODO: handle fv data alignment.


### PR DESCRIPTION
Removed extra copies. It reduces memory consumption, improves performance and simplifies the result (it's now flat).

See the justification discussion: https://github.com/linuxboot/fiano/issues/304