### PR TITLE
pkg/visitors: repack must set valid flag in created file

### DIFF
--- a/pkg/visitors/assemble.go
+++ b/pkg/visitors/assemble.go
@@ -228,7 +228,7 @@ func (v *Assemble) Visit(f uefi.Firmware) error {
 
 		// TODO: Not setting to valid used to cause some failures on some bioses, verify that it no longer fails.
 		// There are some bioses that don't set the valid bits correctly,
-		// fh.State = 0x07 ^ uefi.Attributes.ErasePolarity
+		// fh.SetState(uefi.FileStateValid)
 
 		if err = f.ChecksumAndAssemble(fileData); err != nil {
 			return err

--- a/pkg/visitors/repack.go
+++ b/pkg/visitors/repack.go
@@ -116,6 +116,9 @@ func createVolumeImageFile(cs *uefi.Section) (*uefi.File, error) {
 	f := &uefi.File{}
 
 	f.Header.Type = uefi.FVFileTypeVolumeImage
+	// set state to valid
+	f.Header.State = 0x07 ^ uefi.Attributes.ErasePolarity
+
 	f.Sections = []*uefi.Section{cs}
 
 	// Call assemble to populate cs's buffer. then sha1 it for the guid.

--- a/pkg/visitors/repack.go
+++ b/pkg/visitors/repack.go
@@ -116,8 +116,7 @@ func createVolumeImageFile(cs *uefi.Section) (*uefi.File, error) {
 	f := &uefi.File{}
 
 	f.Header.Type = uefi.FVFileTypeVolumeImage
-	// set state to valid
-	f.Header.State = 0x07 ^ uefi.Attributes.ErasePolarity
+	f.Header.SetState(uefi.FileStateValid)
 
 	f.Sections = []*uefi.Section{cs}
 


### PR DESCRIPTION
The created VolumeImageFile must have the State set as valid.
note: This was done by assemble prior to #263