### PR TITLE
fix(firmwarevolume): slice bounds out of range

### DIFF
--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -189,7 +189,7 @@ func FindFirmwareVolumeOffset(data []byte) int64 {
 		offset int64
 		fvSig  = []byte("_FVH")
 	)
-	for offset = 32; offset < int64(len(data)); offset += 8 {
+	for offset = 32; offset+4 < int64(len(data)); offset += 8 {
 		if bytes.Equal(data[offset:offset+4], fvSig) {
 			return offset - 40 // the actual volume starts 40 bytes before the signature
 		}


### PR DESCRIPTION
Just adjusting the condition in for to avoid panic:
```
panic: runtime error: slice bounds out of range [:108] with capacity 105

goroutine 1 [running]:
github.com/linuxboot/fiano/pkg/uefi.FindFirmwareVolumeOffset(0x7f2e2d22c000, 0x69, 0x69, 0xc00015c070)
        .../github.com/linuxboot/fiano/pkg/uefi/firmwarevolume.go:193 +0x105
github.com/linuxboot/fiano/pkg/uefi.NewBIOSRegion(0x7f2e2d22c000, 0x69, 0x69, 0x0, 0x0, 0xc0000945e0, 0x40c1f8, 0x10, 0x5ee700)
        .../github.com/linuxboot/fiano/pkg/uefi/biosregion.go:92 +0x151
github.com/linuxboot/fiano/pkg/uefi.Parse(0x7f2e2d22c000, 0x69, 0x69, 0x0, 0x69, 0x0, 0x0)
        .../github.com/linuxboot/fiano/pkg/uefi/uefi.go:154 +0x79
...
```