### PR TITLE
fix(firmwarevolume): infinite loop

### DIFF
--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -287,6 +287,9 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 		}
 		fv.Files = append(fv.Files, file)
 		prevLen = file.Header.ExtendedSize
+		if prevLen == 0 {
+			return nil, fmt.Errorf("invalid length of file at offset %#x", offset)
+		}
 	}
 	return &fv, nil
 }


### PR DESCRIPTION
Added a break for a loop which was hanging on `file.Header.ExtendedSize == 0`.

I haven't check if the error is returned correctly, yet. I checked only that it helps to avoid the infinite loop described in #311

ITS: https://github.com/linuxboot/fiano/issues/311