### PR TITLE
uefi/meregion: print out what the code is looking for

### DIFF
--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -102,8 +102,7 @@ func FindMEDescriptor(buf []byte) (int, error) {
 		// + 4 since the descriptor starts after the signature
 		return len(MEFTPSignature), nil
 	}
-	return -1, fmt.Errorf("ME Flash Partition Table signature not found: first 20 bytes are:\n%s",
-		hex.Dump(buf[:20]))
+	return -1, fmt.Errorf("ME Flash Partition Table signature %#02x not found: first 20 bytes are:\n%s", MEFTPSignature, hex.Dump(buf[:20]))
 }
 
 // Buf returns the buffer.


### PR DESCRIPTION
The error
ME Flash Partition Table signature not found

leaves one in the dark as to what it IS looking for; change it to print
the thing for which it searcheth:

ME Flash Partition Table signature 0x24465054 not found