### PR TITLE
optimize(read-only): Add flags to optimize read-only operations

### DIFF
--- a/pkg/uefi/biosregion.go
+++ b/pkg/uefi/biosregion.go
@@ -85,8 +85,12 @@ func NewBIOSRegion(buf []byte, r *FlashRegion, _ FlashRegionType) (Region, error
 	var absOffset uint64
 
 	// Copy the buffer
-	br.buf = make([]byte, len(buf))
-	copy(br.buf, buf)
+	if ReadOnly {
+		br.buf = buf
+	} else {
+		br.buf = make([]byte, len(buf))
+		copy(br.buf, buf)
+	}
 
 	for {
 		offset := FindFirmwareVolumeOffset(buf)

--- a/pkg/uefi/file.go
+++ b/pkg/uefi/file.go
@@ -436,10 +436,15 @@ func NewFile(buf []byte) (*File, error) {
 		return nil, fmt.Errorf("File size too big! File with GUID: %v has length %v, but is only %v bytes big",
 			f.Header.GUID, f.Header.ExtendedSize, buflen)
 	}
-	// Copy out the buffer.
-	newBuf := buf[:f.Header.ExtendedSize]
-	f.buf = make([]byte, f.Header.ExtendedSize)
-	copy(f.buf, newBuf)
+
+	if ReadOnly {
+		f.buf = buf[:f.Header.ExtendedSize]
+	} else {
+		// Copy out the buffer.
+		newBuf := buf[:f.Header.ExtendedSize]
+		f.buf = make([]byte, f.Header.ExtendedSize)
+		copy(f.buf, newBuf)
+	}
 
 	// Special case for NVAR Store stored in raw file
 	if f.Header.Type == FVFileTypeRaw && f.Header.GUID == *NVAR {

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -259,10 +259,14 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	fv.FVType = FVGUIDs[fv.FileSystemGUID]
 	fv.FVOffset = fvOffset
 
-	// copy out the buffer.
-	newBuf := data[:fv.Length]
-	fv.buf = make([]byte, fv.Length)
-	copy(fv.buf, newBuf)
+	if ReadOnly {
+		fv.buf = data[:fv.Length]
+	} else {
+		// copy out the buffer.
+		newBuf := data[:fv.Length]
+		fv.buf = make([]byte, fv.Length)
+		copy(fv.buf, newBuf)
+	}
 
 	// Parse the files.
 	// TODO: handle fv data alignment.

--- a/pkg/uefi/uefi.go
+++ b/pkg/uefi/uefi.go
@@ -14,6 +14,19 @@ import (
 	"reflect"
 )
 
+var (
+	// ReadOnly breaks firmware modification operations, but optimizes
+	// memory and CPU consumption for read-only operations.
+	//
+	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING.
+	ReadOnly = false
+
+	// DisableDecompression disables section decompression.
+	//
+	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING.
+	DisableDecompression = false
+)
+
 // ROMAttributes is used to hold global variables that apply across the whole image.
 // We have to do this to avoid passing too many things down each time.
 type ROMAttributes struct {

--- a/pkg/uefi/uefi.go
+++ b/pkg/uefi/uefi.go
@@ -18,12 +18,16 @@ var (
 	// ReadOnly breaks firmware modification operations, but optimizes
 	// memory and CPU consumption for read-only operations.
 	//
-	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING.
+	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING. IF YOU
+	// WILL MODIFY A FIRMWARE WITH THIS OPTION BEING ENABLED, THIS FIRMWARE
+	// MIGHT BRICK YOUR DEVICE.
 	ReadOnly = false
 
 	// DisableDecompression disables section decompression.
 	//
-	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING.
+	// DO NOT USE THIS OPTION UNLESS YOU KNOW WHAT ARE YOU DOING. IF YOU
+	// WILL MODIFY A FIRMWARE WITH THIS OPTION BEING ENABLED, THIS FIRMWARE
+	// MIGHT BRICK YOUR DEVICE.
 	DisableDecompression = false
 )
 


### PR DESCRIPTION
We use fiano to parse UEFI images and we do not need to modify anything or/and decompress, but buffer copies and decompression consumes >90% CPU and a lot of RAM, therefore we add flags to make that disablable.

Predecessor-PR: https://github.com/linuxboot/fiano/pull/305

---

### Benchmark the `uefi.Parse` on EDKII image GALAGOPRO3

Before (with disabled Flags):
```
xaionaro@void:~/go/src/github.com/facebookexternal/pcr0tool/pkg/uefi$ GO111MODULE=off go test ./ -bench=. -benchtime=10s -memprofile=/tmp/heap.pprof 2>&1 | grep -v warning
goos: linux
goarch: amd64
pkg: github.com/facebookexternal/pcr0tool/pkg/uefi
      67         208900801 ns/op        171524652 B/op    856601 allocs/op
PASS
ok      github.com/facebookexternal/pcr0tool/pkg/uefi   15.146s
```

After (with enabled Flags):
```
xaionaro@void:~/go/src/github.com/facebookexternal/pcr0tool/pkg/uefi$ GO111MODULE=off go test ./ -bench=. -benchtime=10s -memprofile=/tmp/heap.pprof 2>&1 | grep -v warning
goos: linux
goarch: amd64
pkg: github.com/facebookexternal/pcr0tool/pkg/uefi
   15480            817542 ns/op           81789 B/op       2594 allocs/op
PASS
ok      github.com/facebookexternal/pcr0tool/pkg/uefi   22.521s
```

---

### Executing our tool one a random sample

Before (with disabled Flags):
```
        User time (seconds): 1.12
        System time (seconds): 0.02
        Percent of CPU this job got: 104%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.10
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 272860
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 10466
        Voluntary context switches: 1002
        Involuntary context switches: 72
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

After (with enabled Flags):
```
        User time (seconds): 0.11
        System time (seconds): 0.01
        Percent of CPU this job got: 106%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.12
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 109988
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 5233
        Voluntary context switches: 186
        Involuntary context switches: 1
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```