### PR TITLE
circleci: fix improper usage of ineffassign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: golint --set_exit_status $(go list ./... | grep -v /vendor/)
       - run:
           name: ineffassign
-          command: ineffassign .
+          command: ineffassign ./...
   test:
     docker:
       - image: circleci/golang:1.12


### PR DESCRIPTION
CI was failing as it was ineffassign . instead of ./...

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>