### PR TITLE
refact(log): Use a replaceable logger

### DIFF
--- a/cmds/fmap/fmap.go
+++ b/cmds/fmap/fmap.go
@@ -36,12 +36,12 @@ import (
 	"hash"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"strconv"
 	"text/template"
 
 	"github.com/linuxboot/fiano/pkg/fmap"
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 var cmds = map[string]struct {
@@ -308,7 +308,7 @@ func verify(a cmdArgs) error {
 	for i, area := range a.f.Areas {
 		if area.Offset+area.Size > a.f.Size {
 			err = errors.New("Invalid flash map")
-			log.Printf("Area %d is out of range", i)
+			log.Errorf("Area %d is out of range", i)
 		}
 	}
 	return err
@@ -330,11 +330,11 @@ func main() {
 	}
 	cmd, ok := cmds[os.Args[1]]
 	if !ok {
-		log.Printf("Invalid command %#v\n", os.Args[1])
+		log.Errorf("Invalid command %#v\n", os.Args[1])
 		printUsage()
 	}
 	if len(os.Args) != cmd.nArgs+3 {
-		log.Printf("Expected %d arguments, got %d\n", cmd.nArgs+3, len(os.Args))
+		log.Errorf("Expected %d arguments, got %d\n", cmd.nArgs+3, len(os.Args))
 		printUsage()
 	}
 
@@ -348,7 +348,7 @@ func main() {
 		// Open file.
 		r, err := os.Open(os.Args[len(os.Args)-1])
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("%v", err)
 		}
 		a.r = r
 		defer r.Close()
@@ -359,13 +359,13 @@ func main() {
 		// Parse fmap.
 		f, m, err := fmap.Read(a.r)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("%v", err)
 		}
 		a.f, a.m = f, m
 	}
 
 	// Execute command.
 	if err := cmd.f(a); err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 }

--- a/cmds/fspinfo/main.go
+++ b/cmds/fspinfo/main.go
@@ -12,9 +12,9 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 
 	"github.com/linuxboot/fiano/pkg/fsp"
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
@@ -54,20 +54,20 @@ func extractFirstFSPHeader(b []byte) (*fsp.InfoHeaderRev3, error) {
 func main() {
 	flag.Parse()
 	if flag.Arg(0) == "" {
-		log.Fatal("Error: missing file name")
+		log.Fatalf("missing file name")
 	}
 	data, err := ioutil.ReadFile(flag.Arg(0))
 	if err != nil {
-		log.Fatalf("Error: cannot read input file: %v", err)
+		log.Fatalf("cannot read input file: %v", err)
 	}
 	hdr, err := extractFirstFSPHeader(data)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 
 	j, err := json.MarshalIndent(hdr, "", "    ")
 	if err != nil {
-		log.Fatalf("Error: cannot marshal JSON: %v", err)
+		log.Fatalf("cannot marshal JSON: %v", err)
 	}
 	if *flagJSON {
 		fmt.Println(string(j))

--- a/cmds/glzma/glzma.go
+++ b/cmds/glzma/glzma.go
@@ -17,9 +17,9 @@ package main
 import (
 	"flag"
 	"io/ioutil"
-	"log"
 
 	"github.com/linuxboot/fiano/pkg/compression"
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 var (
@@ -33,13 +33,13 @@ func main() {
 	flag.Parse()
 
 	if *d == *e {
-		log.Fatal("either decode (-d) or encode (-e) must be set")
+		log.Fatalf("either decode (-d) or encode (-e) must be set")
 	}
 	if *o == "" {
-		log.Fatal("output file must be set")
+		log.Fatalf("output file must be set")
 	}
 	if flag.NArg() != 1 {
-		log.Fatal("expected one input file")
+		log.Fatalf("expected one input file")
 	}
 
 	var compressor compression.Compressor
@@ -58,13 +58,13 @@ func main() {
 
 	in, err := ioutil.ReadFile(flag.Args()[0])
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	out, err := op(in)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	if err := ioutil.WriteFile(*o, out, 0666); err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 }

--- a/cmds/guid2english/main.go
+++ b/cmds/guid2english/main.go
@@ -23,11 +23,11 @@ package main
 import (
 	"flag"
 	"io"
-	"log"
 	"os"
 	"text/template"
 
 	"github.com/linuxboot/fiano/pkg/guid2english"
+	"github.com/linuxboot/fiano/pkg/log"
 	"golang.org/x/text/transform"
 )
 
@@ -48,12 +48,12 @@ func main() {
 		}
 		defer r.Close()
 	default:
-		log.Fatal("Error: At most 1 positional arguments expected")
+		log.Fatalf("At most 1 positional arguments expected")
 	}
 
 	t, err := template.New("guid2english").Parse(*tmpl)
 	if err != nil {
-		log.Fatalf("Error: Template not valid: %v", err)
+		log.Fatalf("Template not valid: %v", err)
 	}
 
 	trans := guid2english.New(guid2english.NewTemplateMapper(t))

--- a/cmds/utk/utk.go
+++ b/cmds/utk/utk.go
@@ -56,8 +56,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/utk"
 	"github.com/linuxboot/fiano/pkg/visitors"
 )
@@ -73,6 +73,6 @@ func init() {
 func main() {
 	flag.Parse()
 	if err := utk.Run(flag.Args()...); err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 }

--- a/pkg/fsp/header.go
+++ b/pkg/fsp/header.go
@@ -9,8 +9,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 // TODO support FSP versions < 2.0
@@ -222,7 +223,7 @@ func NewInfoHeader(b []byte) (*InfoHeaderRev3, error) {
 	}
 	// reserved bytes must be zero'ed
 	if !bytes.Equal(f.Reserved1[:], []byte{0, 0}) {
-		log.Printf("warning: reserved bytes must be zero, got %v", f.Reserved1)
+		log.Warnf("reserved bytes must be zero, got %v", f.Reserved1)
 	}
 	// check spec version
 	// TODO currently, only FSP 2.0 is supported

--- a/pkg/guid/guid.go
+++ b/pkg/guid/guid.go
@@ -9,8 +9,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 const (
@@ -66,7 +67,7 @@ func Parse(s string) (*GUID, error) {
 func MustParse(s string) *GUID {
 	guid, err := Parse(s)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	return guid
 }

--- a/pkg/guid2english/transformer.go
+++ b/pkg/guid2english/transformer.go
@@ -8,12 +8,12 @@ package guid2english
 
 import (
 	"bytes"
-	"log"
 	"regexp"
 	"text/template"
 
 	"github.com/linuxboot/fiano/pkg/guid"
 	"github.com/linuxboot/fiano/pkg/knownguids"
+	"github.com/linuxboot/fiano/pkg/log"
 	"golang.org/x/text/transform"
 )
 
@@ -66,7 +66,7 @@ func (f *TemplateMapper) Map(g guid.GUID) []byte {
 	if err != nil {
 		// There is likely a bug in the template. We do not want to
 		// interrupt the byte stream, so just log the error.
-		log.Printf("Error in template: %v", err)
+		log.Errorf("Error in template: %v", err)
 	}
 	return b.Bytes()
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,65 @@
+// Copyright 2021 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package log
+
+import (
+	"log"
+	"os"
+)
+
+// Logger describes a logger to be used in fiano.
+type Logger interface {
+	// Warnf logs an warning message.
+	Warnf(format string, args ...interface{})
+
+	// Errorf logs an error message.
+	Errorf(format string, args ...interface{})
+
+	// Fatalf logs a fatal message and immediately exits the application
+	// with os.Exit.
+	Fatalf(format string, args ...interface{})
+}
+
+// DefaultLogger is the logger used by default everywhere within fiano.
+var DefaultLogger Logger
+
+func init() {
+	DefaultLogger = logWrapper{Logger: log.New(os.Stderr, "", log.LstdFlags)}
+}
+
+type logWrapper struct {
+	Logger *log.Logger
+}
+
+// Warnf implements Logger.
+func (logger logWrapper) Warnf(format string, args ...interface{}) {
+	logger.Logger.Printf("[fiano][WARN] "+format, args...)
+}
+
+// Errorf implements Logger.
+func (logger logWrapper) Errorf(format string, args ...interface{}) {
+	logger.Logger.Printf("[fiano][ERROR] "+format, args...)
+}
+
+// Fatalf implements Logger.
+func (logger logWrapper) Fatalf(format string, args ...interface{}) {
+	logger.Logger.Fatalf("[fiano][FATAL] "+format, args...)
+}
+
+// Warnf logs an warning message.
+func Warnf(format string, args ...interface{}) {
+	DefaultLogger.Warnf(format, args...)
+}
+
+// Errorf logs an error message.
+func Errorf(format string, args ...interface{}) {
+	DefaultLogger.Errorf(format, args...)
+}
+
+// Fatalf logs a fatal message and immediately exits the application
+// with os.Exit (which is expected to be called by the DefaultLogger.Fatalf).
+func Fatalf(format string, args ...interface{}) {
+	DefaultLogger.Fatalf(format, args...)
+}

--- a/pkg/uefi/file.go
+++ b/pkg/uefi/file.go
@@ -8,9 +8,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
 
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 // FVFileType represents the different types possible in an EFI file.
@@ -450,7 +450,7 @@ func NewFile(buf []byte) (*File, error) {
 	if f.Header.Type == FVFileTypeRaw && f.Header.GUID == *NVAR {
 		ns, err := NewNVarStore(f.buf[f.DataOffset:])
 		if err != nil {
-			log.Printf("error parsing NVAR store in file %v: %v", f.Header.GUID, err)
+			log.Errorf("error parsing NVAR store in file %v: %v", f.Header.GUID, err)
 		}
 		// Note that ns is nil if there was an error, so this assign is fine either way.
 		f.NVarStore = ns

--- a/pkg/uefi/firmwarevolume.go
+++ b/pkg/uefi/firmwarevolume.go
@@ -9,9 +9,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 // FirmwareVolume constants
@@ -273,7 +273,7 @@ func NewFirmwareVolume(data []byte, fvOffset uint64, resizable bool) (*FirmwareV
 	// Start from the end of the fv header.
 	// Test if the fv type is supported.
 	if _, ok := supportedFVs[fv.FileSystemGUID]; !ok {
-		log.Printf("warning unsupported fv type %v,%v not parsing it", fv.FileSystemGUID.String(), fv.FVType)
+		log.Warnf("unsupported fv type %v,%v not parsing it", fv.FileSystemGUID.String(), fv.FVType)
 		return &fv, nil
 	}
 	lh := fv.Length - FileHeaderMinLength

--- a/pkg/uefi/firmwarevolume_test.go
+++ b/pkg/uefi/firmwarevolume_test.go
@@ -7,8 +7,9 @@ package uefi
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"testing"
+
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 var (
@@ -21,7 +22,7 @@ func init() {
 	var err error
 	sampleFV, err = ioutil.ReadFile("../../integration/roms/ovmfSECFV.fv")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 }
 

--- a/pkg/uefi/meregion.go
+++ b/pkg/uefi/meregion.go
@@ -9,7 +9,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"log"
+
+	"github.com/linuxboot/fiano/pkg/log"
 )
 
 // ME Partition parsing, the goal is to spot a padding in the ME Region
@@ -192,7 +193,7 @@ func NewMERegion(buf []byte, r *FlashRegion, rt FlashRegionType) (Region, error)
 	copy(rr.buf, buf)
 	fp, err := NewMEFPT(buf)
 	if err != nil {
-		log.Printf("error parsing ME Flash Partition Table: %v", err)
+		log.Errorf("error parsing ME Flash Partition Table: %v", err)
 		return rr, nil
 	}
 	rr.FPT = fp

--- a/pkg/uefi/section.go
+++ b/pkg/uefi/section.go
@@ -10,11 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"unsafe"
 
 	"github.com/linuxboot/fiano/pkg/compression"
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/unicode"
 )
 
@@ -401,7 +401,7 @@ func NewSection(buf []byte, fileOrder int) (*Section, error) {
 				var err error
 				encapBuf, err = compressor.Decode(buf[typeSpec.DataOffset:])
 				if err != nil {
-					log.Print(err)
+					log.Errorf("%v", err)
 					typeSpec.Compression = "UNKNOWN"
 					encapBuf = []byte{}
 				}
@@ -439,7 +439,7 @@ func NewSection(buf []byte, fileOrder int) (*Section, error) {
 	case SectionTypeDXEDepEx, SectionTypePEIDepEx, SectionMMDepEx:
 		var err error
 		if s.DepEx, err = parseDepEx(s.buf[headerSize:]); err != nil {
-			log.Println("warning:", err)
+			log.Warnf("%v", err)
 		}
 	}
 

--- a/pkg/unicode/ucs2.go
+++ b/pkg/unicode/ucs2.go
@@ -6,8 +6,7 @@
 package unicode
 
 import (
-	"log"
-
+	"github.com/linuxboot/fiano/pkg/log"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -17,7 +16,7 @@ func UCS2ToUTF8(input []byte) string {
 	e := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 	output, _, err := transform.Bytes(e.NewDecoder(), input)
 	if err != nil {
-		log.Printf("could not decode UCS2: %v", err)
+		log.Errorf("could not decode UCS2: %v", err)
 		return string(input)
 	}
 	// Remove null terminator if one exists.
@@ -33,7 +32,7 @@ func UTF8ToUCS2(input string) []byte {
 	input = input + "\000" // null terminator
 	output, _, err := transform.Bytes(e.NewEncoder(), []byte(input))
 	if err != nil {
-		log.Printf("could not encode UCS2: %v", err)
+		log.Errorf("could not encode UCS2: %v", err)
 		return []byte(input)
 	}
 	return output

--- a/pkg/visitors/assemble.go
+++ b/pkg/visitors/assemble.go
@@ -8,11 +8,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"sort"
 
 	"github.com/linuxboot/fiano/pkg/compression"
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 	"github.com/linuxboot/fiano/pkg/unicode"
 )
@@ -81,7 +81,7 @@ func (v *Assemble) Visit(f uefi.Firmware) error {
 			fileBuf := file.Buf()
 			fileLen := uint64(len(fileBuf))
 			if fileLen == 0 {
-				log.Fatal(file.Header.GUID)
+				log.Fatalf("%v", file.Header.GUID)
 			}
 
 			// Pad to the 8 byte alignments.

--- a/pkg/visitors/extract_test.go
+++ b/pkg/visitors/extract_test.go
@@ -6,10 +6,10 @@ package visitors
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
@@ -23,7 +23,7 @@ func init() {
 	var err error
 	sampleFV, err = ioutil.ReadFile("../../integration/roms/ovmfSECFV.fv")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 }
 

--- a/pkg/visitors/find.go
+++ b/pkg/visitors/find.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"regexp"
 
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
@@ -44,7 +44,7 @@ func (v *Find) Run(f uefi.Firmware) error {
 	if v.W != nil {
 		b, err := json.MarshalIndent(v.Matches, "", "\t")
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("%v", err)
 		}
 		fmt.Fprintln(v.W, string(b))
 	}

--- a/pkg/visitors/repack_test.go
+++ b/pkg/visitors/repack_test.go
@@ -6,11 +6,11 @@ package visitors
 
 import (
 	"encoding/binary"
-	"log"
 	"testing"
 
 	"github.com/linuxboot/fiano/pkg/compression"
 	"github.com/linuxboot/fiano/pkg/guid"
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
@@ -35,25 +35,25 @@ func init() {
 	// Level 2 sections: sections that are inside compressed sections.
 	ss1, err = uefi.CreateSection(uefi.SectionTypeRaw, []byte("Subsection 1 data"), nil, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	ss2, err = uefi.CreateSection(uefi.SectionTypeRaw, []byte("Subsection 2 data"), nil, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 
 	// Level 1 sections: includes guid defined compression sections.
 	cs1, err = uefi.CreateSection(uefi.SectionTypeGUIDDefined, nil, []uefi.Firmware{ss1}, &compression.LZMAGUID)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	rs1, err = uefi.CreateSection(uefi.SectionTypeRaw, []byte("Raw section data"), nil, nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 	cs2, err = uefi.CreateSection(uefi.SectionTypeGUIDDefined, nil, []uefi.Firmware{ss2}, &compression.LZMAGUID)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("%v", err)
 	}
 
 	// Sample Files

--- a/pkg/visitors/tightenme.go
+++ b/pkg/visitors/tightenme.go
@@ -6,8 +6,8 @@ package visitors
 
 import (
 	"fmt"
-	"log"
 
+	"github.com/linuxboot/fiano/pkg/log"
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
@@ -82,7 +82,7 @@ func (v *TightenME) process() error {
 	v.br.FRegion.Base = uint16(updateBase)
 	v.br.Length += offsetShift
 	if v.br.Length > 16*1024*1024 {
-		log.Printf("warning new BIOS Regions length %d (%#x) exceed 16MiB limit", v.br.Length, v.br.Length)
+		log.Warnf("new BIOS Regions length %d (%#x) exceed 16MiB limit", v.br.Length, v.br.Length)
 	}
 	// update elements offsets
 	for i, e := range v.br.Elements {


### PR DESCRIPTION
Previously it was impossible to mute fiano without affecting the global logger "log". Now it is possible.

ITS: https://github.com/linuxboot/fiano/issues/330

# Test Plan

## unit-tests

```
xaionaro@void:~/go/src/github.com/linuxboot/fiano$ go test ./...
ok  	github.com/linuxboot/fiano/cmds/fmap	0.065s
ok  	github.com/linuxboot/fiano/cmds/fspinfo	0.009s
?   	github.com/linuxboot/fiano/cmds/glzma	[no test files]
?   	github.com/linuxboot/fiano/cmds/guid2english	[no test files]
?   	github.com/linuxboot/fiano/cmds/utk	[no test files]
ok  	github.com/linuxboot/fiano/integration	4.650s
ok  	github.com/linuxboot/fiano/pkg/compression	6.259s
ok  	github.com/linuxboot/fiano/pkg/fmap	(cached)
ok  	github.com/linuxboot/fiano/pkg/fsp	0.012s
ok  	github.com/linuxboot/fiano/pkg/guid	0.013s
ok  	github.com/linuxboot/fiano/pkg/guid2english	0.025s
?   	github.com/linuxboot/fiano/pkg/knownguids	[no test files]
?   	github.com/linuxboot/fiano/pkg/log	[no test files]
ok  	github.com/linuxboot/fiano/pkg/uefi	0.027s
?   	github.com/linuxboot/fiano/pkg/unicode	[no test files]
?   	github.com/linuxboot/fiano/pkg/utk	[no test files]
ok  	github.com/linuxboot/fiano/pkg/visitors	7.303s
?   	github.com/linuxboot/fiano/scripts/checklicenses	[no test files]
?   	github.com/linuxboot/fiano/scripts/namecollect	[no test files]
```

## end2end

### before

```
xaionaro@void:~/go/src/github.com/9elements/converged-security-suite/pkg/tools$ go test ./... -run=TestCalcImageOffsetNoLogGarbage -count=1
--- FAIL: TestCalcImageOffsetNoLogGarbage (3.84s)
panic: PANIC [recovered]
	panic: PANIC

goroutine 19 [running]:
testing.tRunner.func1.2(0x6236a0, 0x6c3328)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000082900)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/testing/testing.go:1147 +0x4b6
panic(0x6236a0, 0x6c3328)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/runtime/panic.go:965 +0x1b9
github.com/9elements/converged-security-suite/v2/pkg/tools.panicWriter.Write(...)
	/home/xaionaro/go/src/github.com/9elements/converged-security-suite/pkg/tools/ifd_test.go:16
log.(*Logger).Output(0xc0000ac0a0, 0x2, 0xc004d04000, 0x107, 0x0, 0x0)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/log/log.go:184 +0x284
log.Printf(0x68679e, 0x2a, 0xc0048fbcb0, 0x1, 0x1)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/log/log.go:323 +0x85
github.com/linuxboot/fiano/pkg/uefi.NewMERegion(0xc00e8b9000, 0x2fe7000, 0x40ad000, 0xc00001e2c8, 0x1, 0xc0000a80e0, 0x0, 0x1, 0x0)
	/home/xaionaro/go/pkg/mod/github.com/linuxboot/fiano@v6.0.0-rc.0.20210212032429-91b79e9335d4+incompatible/pkg/uefi/meregion.go:195 +0x245
github.com/linuxboot/fiano/pkg/uefi.NewFlashImage(0xc00e8b8000, 0x4000000, 0x40ae000, 0x14, 0x0, 0x0)
	/home/xaionaro/go/pkg/mod/github.com/linuxboot/fiano@v6.0.0-rc.0.20210212032429-91b79e9335d4+incompatible/pkg/uefi/flash.go:276 +0x562
github.com/9elements/converged-security-suite/v2/pkg/tools.GetRegion(0xc00e8b8000, 0x4000000, 0x40ae000, 0x0, 0x0, 0x0, 0x692401)
	/home/xaionaro/go/src/github.com/9elements/converged-security-suite/pkg/tools/ifd.go:25 +0x105
github.com/9elements/converged-security-suite/v2/pkg/tools.CalcImageOffset(0xc00e8b8000, 0x4000000, 0x40ae000, 0x1, 0x0, 0x0, 0x0)
	/home/xaionaro/go/src/github.com/9elements/converged-security-suite/pkg/tools/ifd.go:13 +0x4c
github.com/9elements/converged-security-suite/v2/pkg/tools.TestCalcImageOffsetNoLogGarbage(0xc000082900)
	/home/xaionaro/go/src/github.com/9elements/converged-security-suite/pkg/tools/ifd_test.go:27 +0xde
testing.tRunner(0xc000082900, 0x691c18)
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
	/home/xaionaro/.gimme/versions/go1.16.linux.amd64/src/testing/testing.go:1239 +0x2b3
FAIL	github.com/9elements/converged-security-suite/v2/pkg/tools	3.850s
FAIL
```

### after
```
xaionaro@void:~/go/src/github.com/9elements/converged-security-suite/pkg/tools$ vi ../../go.mod
xaionaro@void:~/go/src/github.com/9elements/converged-security-suite/pkg/tools$ go test ./... -run=TestCalcImageOffsetNoLogGarbage -count=1
go: github.com/linuxboot/fiano@v6.0.0-rc.0.20210423200325-d6d253aa5fc0+incompatible: missing go.sum entry; to add it:
	go mod download github.com/linuxboot/fiano
xaionaro@void:~/go/src/github.com/9elements/converged-security-suite/pkg/tools$ go mod download github.com/linuxboot/fiano
xaionaro@void:~/go/src/github.com/9elements/converged-security-suite/pkg/tools$ go test ./... -run=TestCalcImageOffsetNoLogGarbage -count=1
ok  	github.com/9elements/converged-security-suite/v2/pkg/tools	2.437s
```