### PR TITLE
Check required size during psp bios tables parsing

### DIFF
--- a/pkg/amd/manifest/firmware.go
+++ b/pkg/amd/manifest/firmware.go
@@ -5,7 +5,6 @@
 package manifest
 
 import (
-	"bytes"
 	"fmt"
 
 	bytes2 "github.com/linuxboot/fiano/pkg/bytes"
@@ -72,7 +71,7 @@ func parsePSPFirmware(firmware Firmware) (*PSPFirmware, error) {
 	var pspDirectoryLevel1Range bytes2.Range
 	if efs.PSPDirectoryTablePointer != 0 && efs.PSPDirectoryTablePointer < uint32(len(image)) {
 		var length uint64
-		pspDirectoryLevel1, length, err = ParsePSPDirectoryTable(bytes.NewBuffer(image[efs.PSPDirectoryTablePointer:]))
+		pspDirectoryLevel1, length, err = ParsePSPDirectoryTable(image[efs.PSPDirectoryTablePointer:])
 		if err == nil {
 			pspDirectoryLevel1Range.Offset = uint64(efs.PSPDirectoryTablePointer)
 			pspDirectoryLevel1Range.Length = length
@@ -90,7 +89,7 @@ func parsePSPFirmware(firmware Firmware) (*PSPFirmware, error) {
 				continue
 			}
 			if entry.LocationOrValue != 0 && entry.LocationOrValue < uint64(len(image)) {
-				pspDirectoryLevel2, length, err := ParsePSPDirectoryTable(bytes.NewBuffer(image[entry.LocationOrValue:]))
+				pspDirectoryLevel2, length, err := ParsePSPDirectoryTable(image[entry.LocationOrValue:])
 				if err == nil {
 					result.PSPDirectoryLevel2 = pspDirectoryLevel2
 					result.PSPDirectoryLevel2Range.Offset = entry.LocationOrValue
@@ -115,7 +114,7 @@ func parsePSPFirmware(firmware Firmware) (*PSPFirmware, error) {
 			continue
 		}
 		var length uint64
-		biosDirectoryLevel1, length, err = ParseBIOSDirectoryTable(bytes.NewBuffer(image[offset:]))
+		biosDirectoryLevel1, length, err = ParseBIOSDirectoryTable(image[offset:])
 		if err != nil {
 			continue
 		}
@@ -137,7 +136,7 @@ func parsePSPFirmware(firmware Firmware) (*PSPFirmware, error) {
 				continue
 			}
 			if entry.SourceAddress != 0 && entry.SourceAddress < uint64(len(image)) {
-				biosDirectoryLevel2, length, err := ParseBIOSDirectoryTable(bytes.NewBuffer(image[entry.SourceAddress:]))
+				biosDirectoryLevel2, length, err := ParseBIOSDirectoryTable(image[entry.SourceAddress:])
 				if err == nil {
 					result.BIOSDirectoryLevel2 = biosDirectoryLevel2
 					result.BIOSDirectoryLevel2Range.Offset = entry.SourceAddress

--- a/pkg/amd/manifest/psp_directory_table_test.go
+++ b/pkg/amd/manifest/psp_directory_table_test.go
@@ -5,7 +5,6 @@
 package manifest
 
 import (
-	"bytes"
 	"encoding/binary"
 	"testing"
 )
@@ -64,7 +63,7 @@ func TestFindPSPDirectoryTable(t *testing.T) {
 }
 
 func TestPspDirectoryTableParsing(t *testing.T) {
-	table, length, err := ParsePSPDirectoryTable(bytes.NewBuffer(append(pspDirectoryTableDataChunk, 0xff)))
+	table, length, err := ParsePSPDirectoryTable(append(pspDirectoryTableDataChunk, 0xff))
 	if err != nil {
 		t.Fatalf("Failed to parse PSP Directory table, err: %v", err)
 	}
@@ -93,5 +92,21 @@ func TestPspDirectoryTableParsing(t *testing.T) {
 	}
 	if table.Entries[0].LocationOrValue != 0x62400 {
 		t.Errorf("Table entry [0] location is incorrect: %d, expected: 0x62400", table.Entries[0].LocationOrValue)
+	}
+}
+
+func TestBrokenTotalEntriesPspDirectoryParsing(t *testing.T) {
+	pspDirectoryTableData := make([]byte, len(pspDirectoryTableDataChunk))
+	copy(pspDirectoryTableData, pspDirectoryTableDataChunk)
+
+	// 8 is offset of TotalEntries field
+	pspDirectoryTableData[8] = 0xff
+	pspDirectoryTableData[9] = 0xff
+	pspDirectoryTableData[10] = 0xff
+	pspDirectoryTableData[11] = 0xff
+
+	_, _, err := ParsePSPDirectoryTable(pspDirectoryTableData)
+	if err == nil {
+		t.Errorf("expected error when parsing incorrect psp directory table contents")
 	}
 }


### PR DESCRIPTION
Address: https://github.com/9elements/converged-security-suite/issues/301

Function parsePSPFirmware tries to use information from the Embedded Firmware Structure to find both PSP and BIOS tables. But in case of memory scanning for a cookie this could not be the case. Will also add checksum checks.
