### PR TITLE
Add checksum calculation for AMD's BIOS and PSP Directories

### DIFF
--- a/pkg/amd/manifest/bios_directory_table_test.go
+++ b/pkg/amd/manifest/bios_directory_table_test.go
@@ -11,7 +11,7 @@ import (
 
 var biosDirectoryTableDataChunk = []byte{
 	0x24, 0x42, 0x48, 0x44,
-	0xee, 0x7f, 0xd9, 0xab,
+	0xd0, 0x75, 0xc5, 0xac,
 	0x01, 0x00, 0x00, 0x00,
 	0x40, 0x04, 0x00, 0x20,
 
@@ -78,6 +78,9 @@ func TestBiosDirectoryTableParsing(t *testing.T) {
 
 	if table.BIOSCookie != BIOSDirectoryTableCookie {
 		t.Errorf("BIOSCookie is incorrect: %d, expected: %d", table.BIOSCookie, BIOSDirectoryTableCookie)
+	}
+	if table.Checksum != 0xacc575d0 {
+		t.Errorf("Checksum is incorrect: %d, expected: %d", table.Checksum, 0xacc575d0)
 	}
 	if table.TotalEntries != 1 {
 		t.Errorf("TotalEntries is incorrect: %d, expected: %d", table.TotalEntries, 1)

--- a/pkg/amd/manifest/checksum.go
+++ b/pkg/amd/manifest/checksum.go
@@ -1,0 +1,53 @@
+// Copyright 2019 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package manifest
+
+const (
+	biosDirectoryChecksumDataOffset = 8
+	pspDirectoryChecksumDataOffset  = 8
+)
+
+// CalculateBiosDirectoryCheckSum calculates expected checksum of BIOS Directory represented in serialised form
+func CalculateBiosDirectoryCheckSum(biosDirRaw []byte) uint32 {
+	return fletcherCRC32(biosDirRaw[biosDirectoryChecksumDataOffset:])
+}
+
+// CalculatePSPDirectoryCheckSum calculates expected checksum of PSP Directory represented in serialised form
+func CalculatePSPDirectoryCheckSum(pspDirRaw []byte) uint32 {
+	return fletcherCRC32(pspDirRaw[pspDirectoryChecksumDataOffset:])
+}
+
+func fletcherCRC32(data []byte) uint32 {
+	var c0, c1 uint32
+	var i int
+	l := (len(data) + 1) & ^1
+
+	for l > 0 {
+		blockLen := l
+		if blockLen > 360*2 {
+			blockLen = 360 * 2
+		}
+		l -= blockLen
+
+		for {
+			val := uint16(data[i])
+			i++
+			if i < len(data) {
+				val += uint16(data[i]) << 8
+				i++
+			}
+			c0 = c0 + uint32(val)
+			c1 = c1 + c0
+			blockLen -= 2
+			if blockLen == 0 {
+				break
+			}
+		}
+
+		c0 = c0 % 65535
+		c1 = c1 % 65535
+	}
+	return c1<<16 | c0
+}

--- a/pkg/amd/manifest/checksum_test.go
+++ b/pkg/amd/manifest/checksum_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package manifest
+
+import (
+	"testing"
+)
+
+func TestFletcherCRC32(t *testing.T) {
+	assertEqual := func(expected, actual uint32) {
+		if expected != actual {
+			t.Errorf("Expected: %d, but got: %d", expected, actual)
+		}
+	}
+	assertEqual(0xF04FC729, fletcherCRC32([]byte("abcde")))
+	assertEqual(0x56502D2A, fletcherCRC32([]byte("abcdef")))
+	assertEqual(0xEBE19591, fletcherCRC32([]byte("abcdefgh")))
+}
+
+func TestPSPDirectoryCheckSum(t *testing.T) {
+	actualCheckSum := CalculatePSPDirectoryCheckSum(pspDirectoryTableDataChunk)
+
+	table, _, err := ParsePSPDirectoryTable(pspDirectoryTableDataChunk)
+	if err != nil {
+		t.Fatalf("Failed to parse PSP Directory table, err: %v", err)
+	}
+	if table.Checksum != actualCheckSum {
+		t.Errorf("Incorrect checksum: 0x%X, expected: 0x%X", actualCheckSum, table.Checksum)
+	}
+}
+
+func TestBIOSDirectoryCheckSum(t *testing.T) {
+	actualCheckSum := CalculateBiosDirectoryCheckSum(biosDirectoryTableDataChunk)
+
+	table, _, err := ParseBIOSDirectoryTable(biosDirectoryTableDataChunk)
+	if err != nil {
+		t.Fatalf("Failed to parse PSP Directory table, err: %v", err)
+	}
+	if table.Checksum != actualCheckSum {
+		t.Errorf("Incorrect checksum: 0x%X, expected: 0x%X", actualCheckSum, table.Checksum)
+	}
+}

--- a/pkg/amd/manifest/psp_directory_table_test.go
+++ b/pkg/amd/manifest/psp_directory_table_test.go
@@ -11,7 +11,7 @@ import (
 
 var pspDirectoryTableDataChunk = []byte{
 	0x24, 0x50, 0x53, 0x50,
-	0xcf, 0x55, 0x73, 0x1b,
+	0x57, 0x4d, 0x3f, 0xfc,
 	0x01, 0x00, 0x00, 0x00,
 	0x10, 0x05, 0x00, 0x20,
 
@@ -63,7 +63,8 @@ func TestFindPSPDirectoryTable(t *testing.T) {
 }
 
 func TestPspDirectoryTableParsing(t *testing.T) {
-	table, length, err := ParsePSPDirectoryTable(append(pspDirectoryTableDataChunk, 0xff))
+	data := append(pspDirectoryTableDataChunk, 0xff)
+	table, length, err := ParsePSPDirectoryTable(data)
 	if err != nil {
 		t.Fatalf("Failed to parse PSP Directory table, err: %v", err)
 	}
@@ -75,7 +76,10 @@ func TestPspDirectoryTableParsing(t *testing.T) {
 	}
 
 	if table.PSPCookie != PSPDirectoryTableCookie {
-		t.Errorf("BIOSCookie is incorrect: %d, expected: %d", table.PSPCookie, PSPDirectoryTableCookie)
+		t.Errorf("PSPCookie is incorrect: %d, expected: %d", table.PSPCookie, PSPDirectoryTableCookie)
+	}
+	if table.Checksum != 0xfc3f4d57 {
+		t.Errorf("Checksum is incorrect: %d, expected: %d", table.Checksum, 0xfc3f4d57)
 	}
 	if table.TotalEntries != 1 {
 		t.Errorf("TotalEntries is incorrect: %d, expected: %d", table.TotalEntries, 1)


### PR DESCRIPTION
What a surprise that I found no golang implementation for Fletcher CRC32.