### PR TITLE
Add Intel FIT parser

### DIFF
--- a/pkg/bytes/is_zero_filled_amd64.go
+++ b/pkg/bytes/is_zero_filled_amd64.go
@@ -15,21 +15,21 @@ import (
 // IsZeroFilled returns true if b consists of zeros only.
 func IsZeroFilled(b []byte) bool {
 	hdr := (*reflect.SliceHeader)((unsafe.Pointer)(&b))
-	data := hdr.Data
+	data := unsafe.Pointer(hdr.Data)
 	length := hdr.Len
-	if data&0x07 != 0 {
+	if uintptr(data)&0x07 != 0 {
 		// the data is not aligned, fallback to a simple way
 		return isZeroFilledSimple(b)
 	}
 	dataEnd := hdr.Data + uintptr(length)
 	dataWordsEnd := dataEnd & ^uintptr(0x07)
-	for ; data < dataWordsEnd; data += 8 {
-		if *(*uint64)(unsafe.Pointer(data)) != 0 {
+	for ; uintptr(data) < dataWordsEnd; data = unsafe.Pointer(uintptr(data) + 8) {
+		if *(*uint64)(data) != 0 {
 			return false
 		}
 	}
-	for ; data < dataEnd; data++ {
-		if *(*uint8)(unsafe.Pointer(data)) != 0 {
+	for ; uintptr(data) < dataWordsEnd; data = unsafe.Pointer(uintptr(data) + 1) {
+		if *(*uint8)(data) != 0 {
 			return false
 		}
 	}

--- a/pkg/intel/metadata/fit/consts/consts.go
+++ b/pkg/intel/metadata/fit/consts/consts.go
@@ -1,0 +1,23 @@
+package consts
+
+import (
+	uefiConsts "github.com/9elements/converged-security-suite/v2/pkg/uefi/consts"
+)
+
+const (
+	BasePhysAddr = uefiConsts.BasePhysAddr
+
+	// FITPointerOffset is the offset of the physical address of the FIT pointer.
+	// See "1 Firmware Interface Table" in "Firmware Interface Table" specification:
+	//  * https://www.intel.com/content/dam/www/public/us/en/documents/guides/fit-bios-specification.pdf
+	FITPointerOffset = 0x40
+
+	// FITPointerPhysAddr is the physical address of the FIT pointer.
+	// See "1 Firmware Interface Table" in "Firmware Interface Table" specification:
+	//  * https://www.intel.com/content/dam/www/public/us/en/documents/guides/fit-bios-specification.pdf
+	FITPointerPhysAddr = BasePhysAddr - FITPointerOffset
+
+	// FITPointerSize is the size of the FIT pointer.
+	// It is suggested to be 0x10 bytes because of "Figure 1-1" of the specification.
+	FITPointerSize = 0x10
+)

--- a/pkg/intel/metadata/fit/consts/consts.go
+++ b/pkg/intel/metadata/fit/consts/consts.go
@@ -5,6 +5,7 @@ import (
 )
 
 const (
+	// BasePhysAddr is the physical memory address where the mapped image ends.
 	BasePhysAddr = uefiConsts.BasePhysAddr
 
 	// FITPointerOffset is the offset of the physical address of the FIT pointer.

--- a/pkg/intel/metadata/fit/consts/fit.go
+++ b/pkg/intel/metadata/fit/consts/fit.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	FITHeadersMagic = "_FIT_   "
+)

--- a/pkg/intel/metadata/fit/consts/fit.go
+++ b/pkg/intel/metadata/fit/consts/fit.go
@@ -1,5 +1,7 @@
 package consts
 
 const (
+	// FITHeadersMagic is the magic string, expected in the beginning of the
+	// first FIT entry
 	FITHeadersMagic = "_FIT_   "
 )

--- a/pkg/intel/metadata/fit/entry.go
+++ b/pkg/intel/metadata/fit/entry.go
@@ -1,0 +1,125 @@
+package fit
+
+import (
+	"fmt"
+)
+
+// Entry is the interface common to any FIT entry
+type Entry interface {
+	fmt.GoStringer
+
+	// GetType returns the type of the FIT entry
+	GetType() EntryType
+
+	// GetHeaders returns the FIT entry headers.
+	//
+	// See "Table 1-1" in "1.2 Firmware Interface Table" in "Firmware Interface Table" specification:
+	//  * https://www.intel.com/content/dam/www/public/us/en/documents/guides/fit-bios-specification.pdf
+	GetHeaders() *EntryHeaders
+
+	// GetDataOffset returns the offset of the data of the entry
+	// relatively to the beginning of the firmware image.
+	GetDataOffset() uint64
+
+	// GetDataBytes returns the data of the entry.
+	GetDataBytes() []byte
+
+	// GetHeadersErrors returns the errors were received while processing
+	// the headers of the entry.
+	GetHeadersErrors() []error
+}
+
+// EntriesByType is a helper to sort a slice of `Entry`-ies by their type/class.
+type EntriesByType []Entry
+
+func (entries EntriesByType) Less(i, j int) bool { return entries[i].GetType() < entries[j].GetType() }
+func (entries EntriesByType) Swap(i, j int)      { entries[i], entries[j] = entries[j], entries[i] }
+func (entries EntriesByType) Len() int           { return len(entries) }
+
+// EntryBase is the common information for any FIT entry
+type EntryBase struct {
+	Headers       *EntryHeaders
+	DataOffset    *uint64 `json:",omitempty"`
+	DataBytes     []byte  `json:",omitempty"`
+	HeadersErrors []error `json:",omitempty"`
+}
+
+// GetType returns the type of the FIT entry
+func (entry *EntryBase) GetType() EntryType {
+	return entry.Headers.Type()
+}
+
+// GetHeaders returns the FIT entry headers.
+//
+// See "Table 1-1" in "1.2 Firmware Interface Table" in "Firmware Interface Table" specification:
+//  * https://www.intel.com/content/dam/www/public/us/en/documents/guides/fit-bios-specification.pdf
+func (entry *EntryBase) GetHeaders() *EntryHeaders {
+	return entry.Headers
+}
+
+// GetDataOffset returns the offset of the data of the entry
+// relatively to the beginning of the firmware image.
+func (entry *EntryBase) GetDataOffset() uint64 {
+	return *entry.DataOffset
+}
+
+// GetDataBytes returns the data of the entry.
+func (entry *EntryBase) GetDataBytes() []byte {
+	return entry.DataBytes
+}
+
+// GetHeadersErrors returns the errors were received while processing
+// the headers of the entry.
+func (entry *EntryBase) GetHeadersErrors() []error {
+	return entry.HeadersErrors
+}
+
+// GoString implements fmt.GoStringer
+func (entry *EntryBase) GoString() string {
+	return entry.Headers.GoString()
+}
+
+// Each of these types are extendable, see files "entry_*.go":
+
+// EntryFITHeaderEntry represents a FIT entry of type "FIT Header Entry" (0x00)
+type EntryFITHeaderEntry struct{ EntryBase }
+
+// EntryMicrocodeUpdateEntry represents a FIT entry of type "Microcode Update Entry" (0x01)
+type EntryMicrocodeUpdateEntry struct{ EntryBase }
+
+// EntrySACM represents a FIT entry of type "Startup AC Module Entry" (0x02)
+type EntrySACM struct{ EntryBase }
+
+// EntryBIOSStartupModuleEntry represents a FIT entry of type "BIOS Startup Module Entry" (0x07)
+type EntryBIOSStartupModuleEntry struct{ EntryBase }
+
+// EntryTPMPolicyRecord represents a FIT entry of type "TPM Policy Record" (0x08)
+type EntryTPMPolicyRecord struct{ EntryBase }
+
+// EntryBIOSPolicyRecord represents a FIT entry of type "BIOS Policy Record" (0x09)
+type EntryBIOSPolicyRecord struct{ EntryBase }
+
+// EntryKeyManifestRecord represents a FIT entry of type "Key Manifest Record" (0x0B)
+type EntryKeyManifestRecord struct{ EntryBase }
+
+// EntryTXTPolicyRecord represents a FIT entry of type "TXT Policy Record" (0x0A)
+type EntryTXTPolicyRecord struct{ EntryBase }
+
+// EntryBootPolicyManifestRecord represents a FIT entry of type "Boot Policy Manifest" (0x0C)
+type EntryBootPolicyManifestRecord struct{ EntryBase }
+
+// EntryCSESecureBoot represents a FIT entry of type "CSE Secure Boot" (0x10)
+type EntryCSESecureBoot struct{ EntryBase }
+
+// EntryFeaturePolicyDeliveryRecord represents a FIT entry of type "Feature Policy Delivery Record" (0x2D)
+type EntryFeaturePolicyDeliveryRecord struct{ EntryBase }
+
+// EntryJMP_DebugPolicy represents a FIT entry of type "JMP $ Debug Policy" (0x2F)
+//noinspection GoSnakeCaseUsage
+type EntryJMP_DebugPolicy struct{ EntryBase }
+
+// EntrySkip represents a FIT entry of type "Unused Entry (skip)" (0x7F)
+type EntrySkip struct{ EntryBase }
+
+// EntryUnknown represents an unknown FIT entry type.
+type EntryUnknown struct{ EntryBase }

--- a/pkg/intel/metadata/fit/entry.go
+++ b/pkg/intel/metadata/fit/entry.go
@@ -90,6 +90,9 @@ type EntryMicrocodeUpdateEntry struct{ EntryBase }
 // EntrySACM represents a FIT entry of type "Startup AC Module Entry" (0x02)
 type EntrySACM struct{ EntryBase }
 
+// EntryDiagnosticACM represents a FIT entry of type "Diagnostic ACM" (0x03)
+type EntryDiagnosticACM struct{ EntryBase }
+
 // EntryBIOSStartupModuleEntry represents a FIT entry of type "BIOS Startup Module Entry" (0x07)
 type EntryBIOSStartupModuleEntry struct{ EntryBase }
 

--- a/pkg/intel/metadata/fit/entry.go
+++ b/pkg/intel/metadata/fit/entry.go
@@ -117,9 +117,8 @@ type EntryCSESecureBoot struct{ EntryBase }
 // EntryFeaturePolicyDeliveryRecord represents a FIT entry of type "Feature Policy Delivery Record" (0x2D)
 type EntryFeaturePolicyDeliveryRecord struct{ EntryBase }
 
-// EntryJMP_DebugPolicy represents a FIT entry of type "JMP $ Debug Policy" (0x2F)
-//noinspection GoSnakeCaseUsage
-type EntryJMP_DebugPolicy struct{ EntryBase }
+// EntryJMPDebugPolicy represents a FIT entry of type "JMP $ Debug Policy" (0x2F)
+type EntryJMPDebugPolicy struct{ EntryBase }
 
 // EntrySkip represents a FIT entry of type "Unused Entry (skip)" (0x7F)
 type EntrySkip struct{ EntryBase }

--- a/pkg/intel/metadata/fit/entry_boot_policy_manifest.go
+++ b/pkg/intel/metadata/fit/entry_boot_policy_manifest.go
@@ -1,0 +1,18 @@
+package fit
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/manifest/bootpolicy"
+)
+
+// Parse creates EntryKeyManifestRecord from EntryKeyManifest
+func (entry *EntryBootPolicyManifestRecord) ParseData() (*bootpolicy.Manifest, error) {
+	var bpManifest bootpolicy.Manifest
+	_, err := bpManifest.ReadFrom(bytes.NewReader(entry.GetDataBytes()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse KeyManifest, err: %v", err)
+	}
+	return &bpManifest, nil
+}

--- a/pkg/intel/metadata/fit/entry_boot_policy_manifest.go
+++ b/pkg/intel/metadata/fit/entry_boot_policy_manifest.go
@@ -7,7 +7,7 @@ import (
 	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/manifest/bootpolicy"
 )
 
-// Parse creates EntryKeyManifestRecord from EntryKeyManifest
+// ParseData creates EntryKeyManifestRecord from EntryKeyManifest
 func (entry *EntryBootPolicyManifestRecord) ParseData() (*bootpolicy.Manifest, error) {
 	var bpManifest bootpolicy.Manifest
 	_, err := bpManifest.ReadFrom(bytes.NewReader(entry.GetDataBytes()))
@@ -15,4 +15,15 @@ func (entry *EntryBootPolicyManifestRecord) ParseData() (*bootpolicy.Manifest, e
 		return nil, fmt.Errorf("failed to parse KeyManifest, err: %v", err)
 	}
 	return &bpManifest, nil
+}
+
+// ParseBootPolicyManifest returns a boot policy manifest if it was able to
+// parse one.
+func (table Table) ParseBootPolicyManifest(firmware []byte) (*bootpolicy.Manifest, error) {
+	hdr := table.First(EntryTypeBootPolicyManifest)
+	if hdr == nil {
+		return nil, ErrNotFound{}
+	}
+
+	return hdr.GetEntry(firmware).(*EntryBootPolicyManifestRecord).ParseData()
 }

--- a/pkg/intel/metadata/fit/entry_headers.go
+++ b/pkg/intel/metadata/fit/entry_headers.go
@@ -1,0 +1,333 @@
+package fit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/check"
+	"github.com/9elements/converged-security-suite/v2/pkg/errors"
+	uefiConsts "github.com/9elements/converged-security-suite/v2/pkg/uefi/consts"
+)
+
+var (
+	entryHeadersSize = uint(binary.Size(EntryHeaders{}))
+)
+
+// EntryHeaders implements a "FIT Entry Format".
+//
+// See "Table 1-1" in "1.2 Firmware Interface Table" in "Firmware Interface Table" specification:
+//  * https://www.intel.com/content/dam/www/public/us/en/documents/guides/fit-bios-specification.pdf
+//
+// Descriptions of the fields are adapted descriptions from the document by the link above.
+type EntryHeaders struct {
+	// Address is the base address of the firmware component.
+	// Must be aligned on 16 byte boundary.
+	Address Address64
+
+	Size Size24M16 `json:"Size24M16"`
+
+	// Reserved should always be equal to zero.
+	Reserved uint8 `json:",omitempty"`
+
+	Version EntryVersion
+
+	TypeAndIsChecksumValid TypeAndIsChecksumValid
+
+	Checksum uint8 `json:",omitempty"`
+}
+
+func (hdr *EntryHeaders) GoString() string {
+	var result strings.Builder
+	result.WriteString(fmt.Sprintf("   Address: 0x%x\n", hdr.Address.Pointer()))
+	result.WriteString(fmt.Sprintf("   size: 0x%x\n", uint16(hdr.Size.Size())))
+	result.WriteString(fmt.Sprintf("   Version: 0x%x\n", uint16(hdr.Version)))
+	result.WriteString(fmt.Sprintf("   Type: 0x%x\n", uint8(hdr.TypeAndIsChecksumValid)))
+	result.WriteString(fmt.Sprintf("   Checksum: 0x%x\n", hdr.Checksum))
+	return result.String()
+}
+
+// Size24M16 is a 24 bit value of a size in multiple of 16 bytes
+type Size24M16 struct {
+	Value [3]byte
+}
+
+// Size returns the size in bytes
+func (size Size24M16) Size() uint32 {
+	b := make([]byte, 4)
+	copy(b[:], size.Value[:])
+	return binary.LittleEndian.Uint32(b) << 4
+}
+
+// Address64 is a 64bit address type
+type Address64 uint64
+
+// Pointer returns the pointer which could be used for pointer arithmetics.
+func (addr Address64) Pointer() uint64 { return uint64(addr) }
+func (addr Address64) String() string  { return fmt.Sprintf("0x%x", addr.Pointer()) }
+
+// EntryVersion contains the component's version number in binary
+// coded decimal (BCD) format. For the FIT header entry, the value in this
+// field will indicate the revision number of the FIT data structure.
+// The upper byte of the revision field indicates the major revision and
+// the lower byte indicates the minor revision. The format 0x1234 conveys
+// the major number encoded in the first two digits and the minor number
+// in the last two with a fixed point assumed in between
+type EntryVersion uint16
+
+// Major returns the major part of the entry version
+func (ver EntryVersion) Major() uint8 { return uint8(ver & 0xff00 >> 8) }
+
+// Minor returns the minor part of the entry version
+func (ver EntryVersion) Minor() uint8 { return uint8(ver & 0xff) }
+
+func (ver EntryVersion) String() string {
+	b, _ := ver.MarshalJSON()
+	return string(b)
+}
+
+type entryVersionStruct struct {
+	Major uint8 `json:"maj"`
+	Minor uint8 `json:"min,omitempty"`
+}
+
+// MarshalJSON just implements encoding/json.Marshaler
+func (ver EntryVersion) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&entryVersionStruct{
+		Major: ver.Major(),
+		Minor: ver.Minor(),
+	})
+}
+
+// UnmarshalJSON just implements encoding/json.Unmarshaler
+func (ver *EntryVersion) UnmarshalJSON(b []byte) error {
+	parsed := entryVersionStruct{}
+	err := json.Unmarshal(b, &parsed)
+	if err != nil {
+		return err
+	}
+	*ver = EntryVersion(parsed.Major)<<8 | EntryVersion(parsed.Minor)
+	return nil
+}
+
+// SizeM16 is a size in multiple of 16 bytes (M16).
+type SizeM16 uint16
+
+// Size returns the size in bytes
+func (size SizeM16) Size() uint     { return uint(size) << 4 }
+func (size SizeM16) String() string { return fmt.Sprintf("0x%x*0x10", uint16(size)) }
+
+// TypeAndIsChecksumValid combines two fields:
+// * "C_V" -- Checksum Valid bit. This is a one bit field that indicates,
+//            whether component has a valid checksum. CPU must ignore
+//            "Checksum" field, if C_V bit is not set.
+// * EntryType (see "entry_type.go").
+type TypeAndIsChecksumValid uint8
+
+// IsChecksumValid returns bit "C_V" of the FIT entry.
+//
+// A quote from the specification:
+// Checksum Valid bit. This is a one bit field that indicates, whether
+// component has a valid checksum. CPU must ignore CHKSUM field, if C_V bit is not set.
+func (f TypeAndIsChecksumValid) IsChecksumValid() bool {
+	return f&0x80 != 0
+}
+
+// Type returns field EntryType ("TYPE" of the FIT entry in terms of
+// the specification).
+func (f TypeAndIsChecksumValid) Type() EntryType {
+	return EntryType(f & 0x7f)
+}
+
+func (f TypeAndIsChecksumValid) String() string {
+	b, _ := f.MarshalJSON()
+	return string(b)
+}
+
+type typeAndIsChecksumValidStruct struct {
+	Type            EntryType `json:"type"`
+	IsChecksumValid bool      `json:"isChecksumValid,omitempty"`
+}
+
+// MarshalJSON just implements encoding/json.Marshaler
+func (f TypeAndIsChecksumValid) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&typeAndIsChecksumValidStruct{
+		IsChecksumValid: f.IsChecksumValid(),
+		Type:            f.Type(),
+	})
+}
+
+// UnmarshalJSON just implements encoding/json.Unmarshaler
+func (f *TypeAndIsChecksumValid) UnmarshalJSON(b []byte) error {
+	parsed := typeAndIsChecksumValidStruct{}
+	err := json.Unmarshal(b, &parsed)
+	if err != nil {
+		return err
+	}
+	if parsed.Type >= 0x80 {
+		return fmt.Errorf(`"type" value is too high`)
+	}
+	*f = TypeAndIsChecksumValid(parsed.Type & 0x7f)
+	if parsed.IsChecksumValid {
+		*f |= 0x80
+	}
+	return nil
+}
+
+// GetEntry returns a full entry (headers + data).
+func (hdr EntryHeaders) GetEntry(firmware []byte) Entry {
+	return hdr.newEntryFromBytes(firmware)
+}
+
+func (hdr EntryHeaders) GetEntryFrom(firmware io.ReadSeeker, firmwareLength uint64) Entry {
+	return hdr.newEntryFromReader(firmware, firmwareLength)
+}
+
+func (hdr *EntryHeaders) getDataCoordinates(firmware io.ReadSeeker, firmwareLength uint64) (forcedBytes []byte, startIdx *uint64, dataSize *uint32, errs []error) {
+	_startIdx := uefiConsts.CalculateOffsetFromPhysAddr(hdr.Address.Pointer(), firmwareLength)
+	_dataSize := hdr.Size.Size()
+
+	switch hdr.Type() {
+	case EntryTypeFITHeaderEntry:
+		// See "1.2.2" of the specification.
+		// FITHeaderEntry contains "_FIT_  " string instead of an address.
+		// And we shouldn't do anything in this case.
+		return nil, nil, nil, nil
+	case EntryTypeStartupACModuleEntry:
+		// See point "7" of "2.7" of the specification: the size field is
+		// always zero. So we parsing the size from it's data right now:
+		var err error
+		_dataSize, err = EntrySACMParseSizeFrom(firmware, _startIdx)
+		if err != nil {
+			return nil, nil, nil, []error{err}
+		}
+	case EntryTypeTXTPolicyRecord:
+		// See "1.2.8" of the specification.
+		// The "Address" field is actually the structure in this case :(
+		var buf bytes.Buffer
+		err := binary.Write(&buf, binary.LittleEndian, &hdr.Address)
+		if err != nil {
+			return nil, nil, nil, []error{err}
+		}
+		return buf.Bytes(), nil, nil, nil
+	}
+
+	if _dataSize == 0 {
+		return nil, nil, nil, []error{fmt.Errorf("data size is zero")}
+	}
+
+	return nil, &_startIdx, &_dataSize, nil
+}
+
+func (hdr *EntryHeaders) newBaseFromBytes(firmware []byte) (result EntryBase) {
+	forcedData, startIdx, dataSize, errs := hdr.getDataCoordinates(bytes.NewReader(firmware), uint64(len(firmware)))
+	result = EntryBase{
+		Headers:       hdr,
+		DataOffset:    startIdx,
+		DataBytes:     forcedData,
+		HeadersErrors: errs,
+	}
+	if forcedData != nil || errs != nil || startIdx == nil || dataSize == nil {
+		return
+	}
+	endIdx := *startIdx + uint64(*dataSize)
+
+	if err := check.BytesRange(firmware, int(*startIdx), int(endIdx)); err != nil {
+		result.HeadersErrors = append(result.HeadersErrors, err.(errors.MultiError)...)
+		return
+	}
+
+	result.DataBytes = firmware[*startIdx:endIdx]
+	return
+}
+
+func (hdr *EntryHeaders) newBaseFromReader(firmware io.ReadSeeker, firmwareLength uint64) (result EntryBase) {
+	forcedData, startIdx, dataSize, errs := hdr.getDataCoordinates(firmware, firmwareLength)
+	result = EntryBase{
+		Headers:       hdr,
+		DataOffset:    startIdx,
+		DataBytes:     forcedData,
+		HeadersErrors: errs,
+	}
+	if forcedData != nil || errs != nil || startIdx == nil || dataSize == nil {
+		return
+	}
+
+	_, err := firmware.Seek(int64(*startIdx), io.SeekStart)
+	if err != nil {
+		result.HeadersErrors = append(result.HeadersErrors, fmt.Errorf("unable to seek(%d): %w", *startIdx, err))
+		return
+	}
+
+	forcedData = make([]byte, *dataSize)
+	n, err := firmware.Read(forcedData)
+	if err != nil {
+		result.HeadersErrors = append(result.HeadersErrors, fmt.Errorf("unable to read %d bytes at %d: %w", *dataSize, *startIdx, err))
+		return
+	}
+	if n != int(*dataSize) {
+		result.HeadersErrors = append(result.HeadersErrors, fmt.Errorf("read length != expected length: %d != %d", n, *dataSize))
+		return
+	}
+	result.DataBytes = forcedData
+
+	return
+}
+
+func (hdr *EntryHeaders) newEntryFromReader(firmware io.ReadSeeker, firmwareLength uint64) Entry {
+	return hdr.newEntryFromBase(hdr.newBaseFromReader(firmware, firmwareLength))
+}
+
+func (hdr *EntryHeaders) newEntryFromBytes(firmware []byte) Entry {
+	return hdr.newEntryFromBase(hdr.newBaseFromBytes(firmware))
+}
+
+func (hdr *EntryHeaders) newEntryFromBase(entryBase EntryBase) Entry {
+	switch hdr.Type() {
+	case EntryTypeFITHeaderEntry:
+		return &EntryFITHeaderEntry{entryBase}
+	case EntryTypeMicrocodeUpdateEntry:
+		return &EntryMicrocodeUpdateEntry{entryBase}
+	case EntryTypeStartupACModuleEntry:
+		return &EntrySACM{entryBase}
+	case EntryTypeBIOSStartupModuleEntry:
+		return &EntryBIOSStartupModuleEntry{entryBase}
+	case EntryTypeTPMPolicyRecord:
+		return &EntryTPMPolicyRecord{entryBase}
+	case EntryTypeBIOSPolicyRecord:
+		return &EntryBIOSPolicyRecord{entryBase}
+	case EntryTypeTXTPolicyRecord:
+		return &EntryTXTPolicyRecord{entryBase}
+	case EntryTypeKeyManifestRecord:
+		return &EntryKeyManifestRecord{entryBase}
+	case EntryTypeBootPolicyManifest:
+		return &EntryBootPolicyManifestRecord{entryBase}
+	case EntryTypeCSESecureBoot:
+		return &EntryCSESecureBoot{entryBase}
+	case EntryTypeFeaturePolicyDeliveryRecord:
+		return &EntryFeaturePolicyDeliveryRecord{entryBase}
+	case EntryTypeJMP_DebugPolicy:
+		return &EntryJMP_DebugPolicy{entryBase}
+	case EntryTypeSkip:
+		return &EntrySkip{entryBase}
+	default:
+		return &EntryUnknown{entryBase}
+	}
+}
+
+// Type returns the type of the FIT entry
+func (hdr *EntryHeaders) Type() EntryType {
+	return hdr.TypeAndIsChecksumValid.Type()
+}
+
+// IsChecksumValid returns if bit "C_V" has value "1".
+func (hdr *EntryHeaders) IsChecksumValid() bool {
+	return hdr.TypeAndIsChecksumValid.IsChecksumValid()
+}
+
+func (hdr *EntryHeaders) String() string {
+	return fmt.Sprintf("&%+v", *hdr)
+}

--- a/pkg/intel/metadata/fit/entry_headers.go
+++ b/pkg/intel/metadata/fit/entry_headers.go
@@ -40,6 +40,7 @@ type EntryHeaders struct {
 	Checksum uint8 `json:",omitempty"`
 }
 
+// GoString implements fmt.GoStringer.
 func (hdr *EntryHeaders) GoString() string {
 	var result strings.Builder
 	result.WriteString(fmt.Sprintf("   Address: 0x%x\n", hdr.Address.Pointer()))
@@ -182,11 +183,12 @@ func (f *TypeAndIsChecksumValid) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// GetEntry returns a full entry (headers + data).
+// GetEntry returns a full entry (headers + data)
 func (hdr EntryHeaders) GetEntry(firmware []byte) Entry {
 	return hdr.newEntryFromBytes(firmware)
 }
 
+// GetEntryFrom returns a full entry (headers + data)
 func (hdr EntryHeaders) GetEntryFrom(firmware io.ReadSeeker, firmwareLength uint64) Entry {
 	return hdr.newEntryFromReader(firmware, firmwareLength)
 }
@@ -339,8 +341,8 @@ func (hdr *EntryHeaders) newEntryFromBase(entryBase EntryBase) Entry {
 		return &EntryCSESecureBoot{entryBase}
 	case EntryTypeFeaturePolicyDeliveryRecord:
 		return &EntryFeaturePolicyDeliveryRecord{entryBase}
-	case EntryTypeJMP_DebugPolicy:
-		return &EntryJMP_DebugPolicy{entryBase}
+	case EntryTypeJMPDebugPolicy:
+		return &EntryJMPDebugPolicy{entryBase}
 	case EntryTypeSkip:
 		return &EntrySkip{entryBase}
 	default:

--- a/pkg/intel/metadata/fit/entry_key_manifest_record.go
+++ b/pkg/intel/metadata/fit/entry_key_manifest_record.go
@@ -1,0 +1,18 @@
+package fit
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/manifest/key"
+)
+
+// Parse creates EntryKeyManifestRecord from EntryKeyManifest
+func (entry *EntryKeyManifestRecord) ParseData() (*key.Manifest, error) {
+	var km key.Manifest
+	_, err := km.ReadFrom(bytes.NewReader(entry.GetDataBytes()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse KeyManifest, err: %v", err)
+	}
+	return &km, nil
+}

--- a/pkg/intel/metadata/fit/entry_key_manifest_record.go
+++ b/pkg/intel/metadata/fit/entry_key_manifest_record.go
@@ -7,7 +7,7 @@ import (
 	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/manifest/key"
 )
 
-// Parse creates EntryKeyManifestRecord from EntryKeyManifest
+// ParseData creates EntryKeyManifestRecord from EntryKeyManifest
 func (entry *EntryKeyManifestRecord) ParseData() (*key.Manifest, error) {
 	var km key.Manifest
 	_, err := km.ReadFrom(bytes.NewReader(entry.GetDataBytes()))
@@ -15,4 +15,15 @@ func (entry *EntryKeyManifestRecord) ParseData() (*key.Manifest, error) {
 		return nil, fmt.Errorf("failed to parse KeyManifest, err: %v", err)
 	}
 	return &km, nil
+}
+
+// ParseKeyManifest returns a boot policy manifest if it was able to
+// parse one.
+func (table Table) ParseKeyManifest(firmware []byte) (*key.Manifest, error) {
+	hdr := table.First(EntryTypeKeyManifestRecord)
+	if hdr == nil {
+		return nil, ErrNotFound{}
+	}
+
+	return hdr.GetEntry(firmware).(*EntryKeyManifestRecord).ParseData()
 }

--- a/pkg/intel/metadata/fit/entry_startup_ac_module_entry.go
+++ b/pkg/intel/metadata/fit/entry_startup_ac_module_entry.go
@@ -1,0 +1,388 @@
+package fit
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/errors"
+)
+
+// See the section "A.1" of the specification
+// "Intel ® Trusted Execution Technology (Intel ® TXT)"
+// https://www.intel.com/content/www/us/en/software-developers/txt-software-development-guide.html
+
+// EntrySACMDataInterface is the interface of a startup AC module
+// data (of any version)
+type EntrySACMDataInterface interface {
+
+	// Field getters:
+
+	GetModuleType() ACModuleType
+	GetModuleSubType() ACModuleSubType
+	GetHeaderLen() SizeM4
+	GetHeaderVersion() ACModuleHeaderVersion
+	GetChipsetID() ACChipsetID
+	GetFlags() ACFlags
+	GetModuleVendor() ACModuleVendor
+	GetDate() BCDDate
+	GetSize() SizeM4
+	GetTXTSVN() TXTSVN
+	GetSESVN() SESVN
+	GetCodeControl() CodeControl
+	GetErrorEntryPoint() ErrorEntryPoint
+	GetGDTLimit() GDTLimit
+	GetGDTBasePtr() GDTBasePtr
+	GetSegSel() SegSel
+	GetEntryPoint() EntryPoint
+	GetReserved2() [64]byte
+	GetKeySize() SizeM4
+	GetScratchSize() SizeM4
+	GetRSAPubKey() rsa.PublicKey
+	GetRSAPubExp() uint32
+	GetRSASig() []byte
+	GetScratch() []byte
+
+	// Auxiliary methods:
+	RSASigBinaryOffset() uint64
+
+	// DateBinaryOffset returns the offset of the field 'Date'
+	// relatively to the beginning of the structure in the binary
+	// format (see 'encoding/binary').
+	DateBinaryOffset() uint
+}
+
+// ACModuleType defines the type of AC module
+type ACModuleType uint16
+
+// ACModuleSubType defines the subtype of AC module (0 - TXT ACM; 1 - S-ACM)
+type ACModuleSubType uint16
+
+// ACModuleHeaderVersion defines module format version:
+// * 0.0 – for SINIT ACM before 2017
+// * 3.0 – for SINIT ACM of converge of BtG and TXT
+type ACModuleHeaderVersion uint32
+
+const (
+	// ACHeaderVersion0 is version "0.0 – for SINIT ACM before 2017"
+	ACHeaderVersion0 = ACModuleHeaderVersion(0x0000)
+
+	// ACHeaderVersion3 is version "3.0 – for SINIT ACM of converge of BtG and TXT"
+	ACHeaderVersion3 = ACModuleHeaderVersion(0x0300)
+)
+
+// ACChipsetID defines the module release identifier
+type ACChipsetID uint16
+
+// ACFlags defines the module-specific flags
+type ACFlags uint16
+
+// ACModuleVendor defines the module vendor identifier
+type ACModuleVendor uint32
+
+// BCDDate is a date in format ("year.month.day").
+type BCDDate uint32
+
+// SizeM4 is a size in multiples of four bytes
+type SizeM4 uint32
+
+// Size return the size in bytes
+func (size SizeM4) Size() uint64   { return uint64(size) << 2 }
+func (size SizeM4) String() string { return fmt.Sprintf("%d*4", uint32(size)) }
+
+// TXTSVN is the TXT Security Version Number
+type TXTSVN uint16
+
+// SESVN is the Software Guard Extensions (Secure Enclaves) Security Version Number
+type SESVN uint16
+
+// CodeControl is the authenticated code control flags
+type CodeControl uint32
+
+// ErrorEntryPoint is the error response entry point offset (bytes)
+type ErrorEntryPoint uint32
+
+// Pointer returns the value of ErrorEntryPoint as a pointer which
+// could be used for pointer arithmetics.
+func (ptr ErrorEntryPoint) Pointer() uint64 { return uint64(ptr) }
+
+// GDTLimit is the GDT limit (defines last byte of GDT)
+type GDTLimit uint32
+
+// GDTBasePtr is the GDT base pointer offset (bytes)
+type GDTBasePtr uint32
+
+// Offset returns the GDTBasePtr value as a pointer which
+// could be used for pointer arithmetics.
+func (ptr GDTBasePtr) Offset() uint64 { return uint64(ptr) }
+
+// SegSel is the segment selector initializer
+type SegSel uint32
+
+// EntryPoint is the authenticated code entry point offset (bytes)
+type EntryPoint uint32
+
+type SACMFieldOffset uint32
+
+// EntrySACMDataCommon is the common part from the beginning of a startup AC module
+// entry of any version.
+type EntrySACMDataCommon struct {
+	ModuleType      ACModuleType
+	ModuleSubType   ACModuleSubType
+	HeaderLen       SizeM4
+	HeaderVersion   ACModuleHeaderVersion
+	ChipsetID       ACChipsetID
+	Flags           ACFlags
+	ModuleVendor    ACModuleVendor
+	Date            BCDDate
+	Size            SizeM4
+	TXTSVN          TXTSVN
+	SESVN           SESVN
+	CodeControl     CodeControl
+	ErrorEntryPoint ErrorEntryPoint
+	GDTLimit        GDTLimit
+	GDTBasePtr      GDTBasePtr
+	SegSel          SegSel
+	EntryPoint      EntryPoint
+	Reserved2       [64]byte
+	KeySize         SizeM4
+	ScratchSize     SizeM4
+}
+
+func (entryData *EntrySACMDataCommon) GetModuleType() ACModuleType { return entryData.ModuleType }
+func (entryData *EntrySACMDataCommon) GetModuleSubType() ACModuleSubType {
+	return entryData.ModuleSubType
+}
+func (entryData *EntrySACMDataCommon) GetHeaderLen() SizeM4 { return entryData.HeaderLen }
+func (entryData *EntrySACMDataCommon) GetHeaderVersion() ACModuleHeaderVersion {
+	return entryData.HeaderVersion
+}
+func (entryData *EntrySACMDataCommon) GetChipsetID() ACChipsetID       { return entryData.ChipsetID }
+func (entryData *EntrySACMDataCommon) GetFlags() ACFlags               { return entryData.Flags }
+func (entryData *EntrySACMDataCommon) GetModuleVendor() ACModuleVendor { return entryData.ModuleVendor }
+func (entryData *EntrySACMDataCommon) GetDate() BCDDate                { return entryData.Date }
+func (entryData *EntrySACMDataCommon) GetSize() SizeM4                 { return entryData.Size }
+func (entryData *EntrySACMDataCommon) GetTXTSVN() TXTSVN               { return entryData.TXTSVN }
+func (entryData *EntrySACMDataCommon) GetSESVN() SESVN                 { return entryData.SESVN }
+func (entryData *EntrySACMDataCommon) GetCodeControl() CodeControl     { return entryData.CodeControl }
+func (entryData *EntrySACMDataCommon) GetErrorEntryPoint() ErrorEntryPoint {
+	return entryData.ErrorEntryPoint
+}
+func (entryData *EntrySACMDataCommon) GetGDTLimit() GDTLimit       { return entryData.GDTLimit }
+func (entryData *EntrySACMDataCommon) GetGDTBasePtr() GDTBasePtr   { return entryData.GDTBasePtr }
+func (entryData *EntrySACMDataCommon) GetSegSel() SegSel           { return entryData.SegSel }
+func (entryData *EntrySACMDataCommon) GetEntryPoint() EntryPoint   { return entryData.EntryPoint }
+func (entryData *EntrySACMDataCommon) GetReserved2() [64]byte      { return entryData.Reserved2 }
+func (entryData *EntrySACMDataCommon) GetKeySize() SizeM4          { return entryData.KeySize }
+func (entryData *EntrySACMDataCommon) GetScratchSize() SizeM4      { return entryData.ScratchSize }
+func (entryData *EntrySACMDataCommon) GetRSAPubKey() rsa.PublicKey { return rsa.PublicKey{} }
+func (entryData *EntrySACMDataCommon) GetRSAPubExp() uint32        { return 0 }
+func (entryData *EntrySACMDataCommon) GetRSASig() []byte           { return nil }
+func (entryData *EntrySACMDataCommon) RSASigBinaryOffset() uint64  { return 0 }
+func (entryData *EntrySACMDataCommon) GetScratch() []byte          { return nil }
+
+// HeaderVersionBinaryOffset returns the offset of the field 'HeaderVersion'
+// relatively to the beginning of the structure in the binary
+// format (see 'encoding/binary').
+func (entryData EntrySACMDataCommon) HeaderVersionBinaryOffset() uint {
+	return 8
+}
+
+// DateBinaryOffset returns the offset of the field 'Date'
+// relatively to the beginning of the structure in the binary
+// format (see 'encoding/binary').
+func (entryData EntrySACMDataCommon) DateBinaryOffset() uint {
+	return 20
+}
+
+// SizeBinaryOffset returns the offset of the field 'Size'
+// relatively to the beginning of the structure in the binary
+// format (see 'encoding/binary').
+func (entryData EntrySACMDataCommon) SizeBinaryOffset() uint {
+	return 24
+}
+
+// TXTSVNBinaryOffset returns the offset of the field 'TXTSVN'
+// relatively to the beginning of the structure in the binary
+// format (see 'encoding/binary').
+func (entryData *EntrySACMDataCommon) TXTSVNBinaryOffset() uint64 {
+	return 28
+}
+
+// KeySizeBinaryOffset returns the offset of the field 'KeySize'
+// relatively to the beginning of the structure in the binary
+// format (see 'encoding/binary').
+func (entryData EntrySACMDataCommon) KeySizeBinaryOffset() uint {
+	return 120
+}
+
+type EntrySACMData0 struct {
+	EntrySACMDataCommon
+
+	RSAPubKey [256]byte
+	RSAPubExp [4]byte
+	RSASig    [256]byte
+	Scratch   [572]byte
+}
+
+var entrySACMData0Size = uint(binary.Size(EntrySACMData0{}))
+
+func (entryData *EntrySACMData0) GetRSAPubKey() rsa.PublicKey {
+	pubKey := rsa.PublicKey{
+		N: big.NewInt(0),
+		E: int(entryData.GetRSAPubExp()),
+	}
+	pubKey.N.SetBytes(entryData.RSAPubKey[:])
+	return pubKey
+}
+func (entryData *EntrySACMData0) GetRSAPubExp() uint32 {
+	return binary.LittleEndian.Uint32(entryData.RSAPubExp[:])
+}
+func (entryData *EntrySACMData0) GetRSASig() []byte { return entryData.RSASig[:] }
+func (entryData *EntrySACMData0) RSASigBinaryOffset() uint64 {
+	return uint64(binary.Size(entryData.EntrySACMDataCommon)) +
+		uint64(binary.Size(entryData.RSAPubKey)) +
+		uint64(binary.Size(entryData.RSAPubExp))
+}
+func (entryData *EntrySACMData0) GetScratch() []byte { return entryData.Scratch[:] }
+
+type EntrySACMData3 struct {
+	EntrySACMDataCommon
+
+	RSAPubKey [384]byte
+	RSASig    [384]byte
+	Scratch   [832]byte
+}
+
+var entrySACMData3Size = uint(binary.Size(EntrySACMData3{}))
+
+func (entryData *EntrySACMData3) GetRSAPubKey() rsa.PublicKey {
+	pubKey := rsa.PublicKey{
+		N: big.NewInt(0),
+		E: 0x10001, // see Table 9. "RSAPubExp" of https://www.intel.com/content/www/us/en/software-developers/txt-software-development-guide.html
+	}
+	pubKey.N.SetBytes(entryData.RSAPubKey[:])
+	return pubKey
+}
+func (entryData *EntrySACMData3) GetRSASig() []byte { return entryData.RSASig[:] }
+func (entryData *EntrySACMData3) RSASigBinaryOffset() uint64 {
+	return uint64(binary.Size(entryData.EntrySACMDataCommon)) +
+		uint64(binary.Size(entryData.RSAPubKey))
+}
+func (entryData *EntrySACMData3) GetScratch() []byte { return entryData.Scratch[:] }
+
+type EntrySACMData struct {
+	EntrySACMDataInterface
+
+	UserArea []byte
+}
+
+func (entryData *EntrySACMData) GetCommon() *EntrySACMDataCommon {
+	if entryData == nil {
+		return nil
+	}
+	switch data := entryData.EntrySACMDataInterface.(type) {
+	case *EntrySACMDataCommon:
+		return data
+	case *EntrySACMData0:
+		return &data.EntrySACMDataCommon
+	case *EntrySACMData3:
+		return &data.EntrySACMDataCommon
+	}
+	return nil
+}
+
+func EntrySACMParseSizeFrom(r io.ReadSeeker, offset uint64) (uint32, error) {
+	sizeFieldLocalOffset := EntrySACMDataCommon{}.SizeBinaryOffset()
+	sizeFieldOffset := int64(offset) + int64(sizeFieldLocalOffset)
+	_, err := r.Seek(sizeFieldOffset, io.SeekStart)
+	if err != nil {
+		return 0, fmt.Errorf("unable to seek(%d, start): %w", sizeFieldOffset, err)
+	}
+	var result uint32
+	err = binary.Read(r, binary.LittleEndian, &result)
+	if err != nil {
+		return 0, fmt.Errorf("unable to read: %w", err)
+	}
+	return result << 2, nil
+}
+
+func EntrySACMParseSize(b []byte) (uint32, error) {
+	sizeFieldOffset := EntrySACMDataCommon{}.SizeBinaryOffset()
+	if int(sizeFieldOffset) >= len(b)-4 {
+		return 0, &errors.ErrEndLessThanStart{StartIdx: int(sizeFieldOffset), EndIdx: len(b) - 4}
+	}
+	return binary.LittleEndian.Uint32(b[sizeFieldOffset:]) << 2, nil
+}
+
+func (entry *EntrySACM) ParseData() (*EntrySACMData, error) {
+	common := EntrySACMDataCommon{}
+	if err := binary.Read(bytes.NewReader(entry.DataBytes), binary.LittleEndian, &common); err != nil {
+		return nil, fmt.Errorf("unable to parse startup AC module entry: %w", err)
+	}
+	result := &EntrySACMData{EntrySACMDataInterface: &common, UserArea: nil}
+
+	var requiredKeySize uint64
+	switch common.HeaderVersion {
+	case ACHeaderVersion0:
+		result.EntrySACMDataInterface = &EntrySACMData0{}
+		requiredKeySize = uint64(len(EntrySACMData0{}.RSAPubKey))
+	case ACHeaderVersion3:
+		result.EntrySACMDataInterface = &EntrySACMData3{}
+		requiredKeySize = uint64(len(EntrySACMData3{}.RSAPubKey))
+	default:
+		return result, &ErrUnknownACMHeaderVersion{ACHeaderVersion: common.HeaderVersion}
+	}
+
+	if common.KeySize.Size() != requiredKeySize {
+		return result, &ErrACMInvalidKeySize{ExpectedKeySize: requiredKeySize, RealKeySize: common.KeySize.Size()}
+	}
+
+	if err := binary.Read(bytes.NewReader(entry.DataBytes), binary.LittleEndian, result.EntrySACMDataInterface); err != nil {
+		return result, fmt.Errorf("cannot parse AC header of version %v: %w", common.HeaderVersion, err)
+	}
+
+	// `UserArea` has variable length and therefore was not included into
+	// `EntrySACMData0` and `EntrySACMData3`, but it is in the tail,
+	// so we just calculate the startIndex as the end of
+	// EntrySACMData0/EntrySACMData3.
+	userAreaStartIdx := binary.Size(result.EntrySACMDataInterface)
+	userAreaEndIdx := result.EntrySACMDataInterface.GetSize().Size()
+	result.UserArea = entry.DataBytes[userAreaStartIdx:userAreaEndIdx]
+
+	return result, nil
+}
+
+type entrySACMJSON struct {
+	Headers        *EntryHeaders
+	DataParsed     *EntrySACMData `json:",omitempty"`
+	DataNotParsed  []byte         `json:"DataNotParsedBase64,omitempty"`
+	HeadersErrors  []error
+	DataParseError error
+}
+
+func (entry *EntrySACM) MarshalJSON() ([]byte, error) {
+	result := entrySACMJSON{}
+	result.Headers = entry.Headers
+	result.DataParsed, result.DataParseError = entry.ParseData()
+	result.HeadersErrors = make([]error, len(entry.HeadersErrors))
+	copy(result.HeadersErrors, entry.HeadersErrors)
+	result.DataNotParsed = entry.DataBytes
+	return json.Marshal(&result)
+}
+
+func (entry *EntrySACM) UnmarshalJSON(b []byte) error {
+	result := entrySACMJSON{}
+	err := json.Unmarshal(b, &result)
+	if err != nil {
+		return err
+	}
+	entry.Headers = result.Headers
+	entry.HeadersErrors = result.HeadersErrors
+	entry.DataBytes = result.DataNotParsed
+	return nil
+}

--- a/pkg/intel/metadata/fit/entry_startup_ac_module_entry.go
+++ b/pkg/intel/metadata/fit/entry_startup_ac_module_entry.go
@@ -84,7 +84,7 @@ type ACFlags uint16
 // ACModuleVendor defines the module vendor identifier
 type ACModuleVendor uint32
 
-// BCDDate is a date in format ("year.month.day").
+// BCDDate is a date in format ("year.month.day")
 type BCDDate uint32
 
 // SizeM4 is a size in multiples of four bytes
@@ -126,8 +126,6 @@ type SegSel uint32
 // EntryPoint is the authenticated code entry point offset (bytes)
 type EntryPoint uint32
 
-type SACMFieldOffset uint32
-
 // EntrySACMDataCommon is the common part from the beginning of a startup AC module
 // entry of any version.
 type EntrySACMDataCommon struct {
@@ -153,37 +151,88 @@ type EntrySACMDataCommon struct {
 	ScratchSize     SizeM4
 }
 
+// GetModuleType returns the type of AC module
 func (entryData *EntrySACMDataCommon) GetModuleType() ACModuleType { return entryData.ModuleType }
+
+// GetModuleSubType returns the subtype of AC module (0 - TXT ACM; 1 - S-ACM)
 func (entryData *EntrySACMDataCommon) GetModuleSubType() ACModuleSubType {
 	return entryData.ModuleSubType
 }
+
+// GetHeaderLen returns HeaderLen field value
 func (entryData *EntrySACMDataCommon) GetHeaderLen() SizeM4 { return entryData.HeaderLen }
+
+// GetHeaderVersion returns module format version:
+// * 0.0 – for SINIT ACM before 2017
+// * 3.0 – for SINIT ACM of converge of BtG and TXT
 func (entryData *EntrySACMDataCommon) GetHeaderVersion() ACModuleHeaderVersion {
 	return entryData.HeaderVersion
 }
-func (entryData *EntrySACMDataCommon) GetChipsetID() ACChipsetID       { return entryData.ChipsetID }
-func (entryData *EntrySACMDataCommon) GetFlags() ACFlags               { return entryData.Flags }
+
+// GetChipsetID returns ChipsetID field value
+func (entryData *EntrySACMDataCommon) GetChipsetID() ACChipsetID { return entryData.ChipsetID }
+
+// GetFlags returns Flags field value (the module-specific flags)
+func (entryData *EntrySACMDataCommon) GetFlags() ACFlags { return entryData.Flags }
+
+// GetModuleVendor returns ModuleVendor field value
 func (entryData *EntrySACMDataCommon) GetModuleVendor() ACModuleVendor { return entryData.ModuleVendor }
-func (entryData *EntrySACMDataCommon) GetDate() BCDDate                { return entryData.Date }
-func (entryData *EntrySACMDataCommon) GetSize() SizeM4                 { return entryData.Size }
-func (entryData *EntrySACMDataCommon) GetTXTSVN() TXTSVN               { return entryData.TXTSVN }
-func (entryData *EntrySACMDataCommon) GetSESVN() SESVN                 { return entryData.SESVN }
-func (entryData *EntrySACMDataCommon) GetCodeControl() CodeControl     { return entryData.CodeControl }
+
+// GetDate returns Date field value ("year.month.day")
+func (entryData *EntrySACMDataCommon) GetDate() BCDDate { return entryData.Date }
+
+// GetSize returns Size field value (the size in multiples of four bytes)
+func (entryData *EntrySACMDataCommon) GetSize() SizeM4 { return entryData.Size }
+
+// GetTXTSVN returns TXT security version number
+func (entryData *EntrySACMDataCommon) GetTXTSVN() TXTSVN { return entryData.TXTSVN }
+
+// GetSESVN returns Software Guard Extensions (Secure Enclaves) Security Version Number
+func (entryData *EntrySACMDataCommon) GetSESVN() SESVN { return entryData.SESVN }
+
+// GetCodeControl returns the authenticated code control flags
+func (entryData *EntrySACMDataCommon) GetCodeControl() CodeControl { return entryData.CodeControl }
+
+// GetErrorEntryPoint returns error entry point field value
 func (entryData *EntrySACMDataCommon) GetErrorEntryPoint() ErrorEntryPoint {
 	return entryData.ErrorEntryPoint
 }
-func (entryData *EntrySACMDataCommon) GetGDTLimit() GDTLimit       { return entryData.GDTLimit }
-func (entryData *EntrySACMDataCommon) GetGDTBasePtr() GDTBasePtr   { return entryData.GDTBasePtr }
-func (entryData *EntrySACMDataCommon) GetSegSel() SegSel           { return entryData.SegSel }
-func (entryData *EntrySACMDataCommon) GetEntryPoint() EntryPoint   { return entryData.EntryPoint }
-func (entryData *EntrySACMDataCommon) GetReserved2() [64]byte      { return entryData.Reserved2 }
-func (entryData *EntrySACMDataCommon) GetKeySize() SizeM4          { return entryData.KeySize }
-func (entryData *EntrySACMDataCommon) GetScratchSize() SizeM4      { return entryData.ScratchSize }
+
+// GetGDTLimit returns GDTLimit field value
+func (entryData *EntrySACMDataCommon) GetGDTLimit() GDTLimit { return entryData.GDTLimit }
+
+// GetGDTBasePtr returns the GDT base pointer offset (bytes)
+func (entryData *EntrySACMDataCommon) GetGDTBasePtr() GDTBasePtr { return entryData.GDTBasePtr }
+
+// GetSegSel the segment selector initializer
+func (entryData *EntrySACMDataCommon) GetSegSel() SegSel { return entryData.SegSel }
+
+// GetEntryPoint returns the authenticated code entry point offset (bytes)
+func (entryData *EntrySACMDataCommon) GetEntryPoint() EntryPoint { return entryData.EntryPoint }
+
+// GetReserved2 returns the Reserved2 field value
+func (entryData *EntrySACMDataCommon) GetReserved2() [64]byte { return entryData.Reserved2 }
+
+// GetKeySize returns the KeySize field value (the size in multiples of four bytes)
+func (entryData *EntrySACMDataCommon) GetKeySize() SizeM4 { return entryData.KeySize }
+
+// GetScratchSize returns the ScratchSize field value (the size in multiples of four bytes)
+func (entryData *EntrySACMDataCommon) GetScratchSize() SizeM4 { return entryData.ScratchSize }
+
+// GetRSAPubKey returns the RSA public key
 func (entryData *EntrySACMDataCommon) GetRSAPubKey() rsa.PublicKey { return rsa.PublicKey{} }
-func (entryData *EntrySACMDataCommon) GetRSAPubExp() uint32        { return 0 }
-func (entryData *EntrySACMDataCommon) GetRSASig() []byte           { return nil }
-func (entryData *EntrySACMDataCommon) RSASigBinaryOffset() uint64  { return 0 }
-func (entryData *EntrySACMDataCommon) GetScratch() []byte          { return nil }
+
+// GetRSAPubExp returns the RSA exponent
+func (entryData *EntrySACMDataCommon) GetRSAPubExp() uint32 { return 0 }
+
+// GetRSASig returns the RSA signature.
+func (entryData *EntrySACMDataCommon) GetRSASig() []byte { return nil }
+
+// RSASigBinaryOffset returns the RSA signature offset
+func (entryData *EntrySACMDataCommon) RSASigBinaryOffset() uint64 { return 0 }
+
+// GetScratch returns the Scratch field value
+func (entryData *EntrySACMDataCommon) GetScratch() []byte { return nil }
 
 // HeaderVersionBinaryOffset returns the offset of the field 'HeaderVersion'
 // relatively to the beginning of the structure in the binary
@@ -220,6 +269,7 @@ func (entryData EntrySACMDataCommon) KeySizeBinaryOffset() uint {
 	return 120
 }
 
+// EntrySACMData0 is the structure for ACM of version 0.0.
 type EntrySACMData0 struct {
 	EntrySACMDataCommon
 
@@ -231,6 +281,7 @@ type EntrySACMData0 struct {
 
 var entrySACMData0Size = uint(binary.Size(EntrySACMData0{}))
 
+// GetRSAPubKey returns the RSA public key
 func (entryData *EntrySACMData0) GetRSAPubKey() rsa.PublicKey {
 	pubKey := rsa.PublicKey{
 		N: big.NewInt(0),
@@ -239,17 +290,26 @@ func (entryData *EntrySACMData0) GetRSAPubKey() rsa.PublicKey {
 	pubKey.N.SetBytes(entryData.RSAPubKey[:])
 	return pubKey
 }
+
+// GetRSAPubExp returns the RSA exponent
 func (entryData *EntrySACMData0) GetRSAPubExp() uint32 {
 	return binary.LittleEndian.Uint32(entryData.RSAPubExp[:])
 }
+
+// GetRSASig returns the RSA signature.
 func (entryData *EntrySACMData0) GetRSASig() []byte { return entryData.RSASig[:] }
+
+// RSASigBinaryOffset returns the RSA signature offset
 func (entryData *EntrySACMData0) RSASigBinaryOffset() uint64 {
 	return uint64(binary.Size(entryData.EntrySACMDataCommon)) +
 		uint64(binary.Size(entryData.RSAPubKey)) +
 		uint64(binary.Size(entryData.RSAPubExp))
 }
+
+// GetScratch returns the Scratch field value
 func (entryData *EntrySACMData0) GetScratch() []byte { return entryData.Scratch[:] }
 
+// EntrySACMData3 is the structure for ACM of version 3.0
 type EntrySACMData3 struct {
 	EntrySACMDataCommon
 
@@ -260,6 +320,7 @@ type EntrySACMData3 struct {
 
 var entrySACMData3Size = uint(binary.Size(EntrySACMData3{}))
 
+// GetRSAPubKey returns the RSA public key
 func (entryData *EntrySACMData3) GetRSAPubKey() rsa.PublicKey {
 	pubKey := rsa.PublicKey{
 		N: big.NewInt(0),
@@ -268,19 +329,27 @@ func (entryData *EntrySACMData3) GetRSAPubKey() rsa.PublicKey {
 	pubKey.N.SetBytes(entryData.RSAPubKey[:])
 	return pubKey
 }
+
+// GetRSASig returns the RSA signature.
 func (entryData *EntrySACMData3) GetRSASig() []byte { return entryData.RSASig[:] }
+
+// RSASigBinaryOffset returns the RSA signature offset
 func (entryData *EntrySACMData3) RSASigBinaryOffset() uint64 {
 	return uint64(binary.Size(entryData.EntrySACMDataCommon)) +
 		uint64(binary.Size(entryData.RSAPubKey))
 }
+
+// GetScratch returns the Scratch field value
 func (entryData *EntrySACMData3) GetScratch() []byte { return entryData.Scratch[:] }
 
+// EntrySACMData combines the structure for ACM and the user area.
 type EntrySACMData struct {
 	EntrySACMDataInterface
 
 	UserArea []byte
 }
 
+// GetCommon returns the common part of the structures for different ACM versions.
 func (entryData *EntrySACMData) GetCommon() *EntrySACMDataCommon {
 	if entryData == nil {
 		return nil
@@ -296,6 +365,7 @@ func (entryData *EntrySACMData) GetCommon() *EntrySACMDataCommon {
 	return nil
 }
 
+// EntrySACMParseSizeFrom parses SACM structure size
 func EntrySACMParseSizeFrom(r io.ReadSeeker, offset uint64) (uint32, error) {
 	sizeFieldLocalOffset := EntrySACMDataCommon{}.SizeBinaryOffset()
 	sizeFieldOffset := int64(offset) + int64(sizeFieldLocalOffset)
@@ -311,6 +381,7 @@ func EntrySACMParseSizeFrom(r io.ReadSeeker, offset uint64) (uint32, error) {
 	return result << 2, nil
 }
 
+// EntrySACMParseSize parses SACM structure size
 func EntrySACMParseSize(b []byte) (uint32, error) {
 	sizeFieldOffset := EntrySACMDataCommon{}.SizeBinaryOffset()
 	if int(sizeFieldOffset) >= len(b)-4 {
@@ -319,6 +390,7 @@ func EntrySACMParseSize(b []byte) (uint32, error) {
 	return binary.LittleEndian.Uint32(b[sizeFieldOffset:]) << 2, nil
 }
 
+// ParseData parses SACM entry and returns EntrySACMData.
 func (entry *EntrySACM) ParseData() (*EntrySACMData, error) {
 	common := EntrySACMDataCommon{}
 	if err := binary.Read(bytes.NewReader(entry.DataBytes), binary.LittleEndian, &common); err != nil {
@@ -365,6 +437,7 @@ type entrySACMJSON struct {
 	DataParseError error
 }
 
+// MarshalJSON implements json.Marshaler
 func (entry *EntrySACM) MarshalJSON() ([]byte, error) {
 	result := entrySACMJSON{}
 	result.Headers = entry.Headers
@@ -375,6 +448,7 @@ func (entry *EntrySACM) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&result)
 }
 
+// UnmarshalJSON implements json.Unmarshaller
 func (entry *EntrySACM) UnmarshalJSON(b []byte) error {
 	result := entrySACMJSON{}
 	err := json.Unmarshal(b, &result)

--- a/pkg/intel/metadata/fit/entry_startup_ac_module_entry_test.go
+++ b/pkg/intel/metadata/fit/entry_startup_ac_module_entry_test.go
@@ -1,0 +1,89 @@
+package fit
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func randBytes(size uint) []byte {
+	rand.Seed(0)
+	b := make([]byte, int(size))
+	rand.Read(b)
+	return b
+}
+
+func TestEntrySACM_ParseData(t *testing.T) {
+	sizeOffset := EntrySACMDataCommon{}.SizeBinaryOffset()
+	sizeEndOffset := sizeOffset + uint(binary.Size(EntrySACMDataCommon{}.Size))
+
+	versionOffset := EntrySACMDataCommon{}.HeaderVersionBinaryOffset()
+	versionEndOffset := versionOffset + uint(binary.Size(EntrySACMDataCommon{}.HeaderVersion))
+
+	keySizeOffset := EntrySACMDataCommon{}.KeySizeBinaryOffset()
+	keySizeEndOffset := keySizeOffset + uint(binary.Size(EntrySACMDataCommon{}.KeySize))
+
+	entry := EntrySACM{
+		EntryBase: EntryBase{
+			Headers:       nil,
+			DataOffset:    nil,
+			DataBytes:     randBytes(65536),
+			HeadersErrors: nil,
+		},
+	}
+
+	t.Run("SACMv0", func(t *testing.T) {
+		binary.LittleEndian.PutUint32(entry.DataBytes[versionOffset:versionEndOffset], uint32(ACHeaderVersion0))
+		binary.LittleEndian.PutUint32(entry.DataBytes[sizeOffset:sizeEndOffset], uint32(entrySACMData0Size)>>2)
+		dataSize, err := EntrySACMParseSize(entry.DataBytes[:65536])
+		require.NoError(t, err)
+		entry.DataBytes = entry.DataBytes[:dataSize]
+		t.Run("positive", func(t *testing.T) {
+			binary.LittleEndian.PutUint32(entry.DataBytes[keySizeOffset:keySizeEndOffset], 256>>2)
+
+			data, err := entry.ParseData()
+			require.NoError(t, err)
+
+			_ = data.GetRSAPubKey()
+			require.Zero(t, len(data.UserArea))
+			require.Zero(t, len(entry.DataBytes)-int(entrySACMData0Size))
+		})
+	})
+
+	t.Run("SACMv3", func(t *testing.T) {
+		binary.LittleEndian.PutUint32(entry.DataBytes[versionOffset:versionEndOffset], uint32(ACHeaderVersion3))
+		binary.LittleEndian.PutUint32(entry.DataBytes[sizeOffset:sizeEndOffset], uint32(entrySACMData3Size)>>2)
+		dataSize, err := EntrySACMParseSize(entry.DataBytes[:65536])
+		require.NoError(t, err)
+		entry.DataBytes = entry.DataBytes[:dataSize]
+		t.Run("positive", func(t *testing.T) {
+			binary.LittleEndian.PutUint32(entry.DataBytes[keySizeOffset:keySizeEndOffset], 384>>2)
+
+			data, err := entry.ParseData()
+			require.NoError(t, err)
+
+			_ = data.GetRSAPubKey()
+			require.Zero(t, len(data.UserArea))
+			require.Zero(t, len(entry.DataBytes)-int(entrySACMData3Size))
+		})
+		t.Run("negative_keySize", func(t *testing.T) {
+			binary.LittleEndian.PutUint32(entry.DataBytes[keySizeOffset:keySizeEndOffset], 256>>2)
+
+			_, err := entry.ParseData()
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("SACM_invalidVersion", func(t *testing.T) {
+		binary.LittleEndian.PutUint32(entry.DataBytes[versionOffset:versionEndOffset], 0x12345678)
+		binary.LittleEndian.PutUint32(entry.DataBytes[sizeOffset:sizeEndOffset], uint32(entrySACMData0Size)>>2)
+		dataSize, err := EntrySACMParseSize(entry.DataBytes[:65536])
+		require.NoError(t, err)
+		entry.DataBytes = entry.DataBytes[:dataSize]
+
+		_, err = entry.ParseData()
+		require.Error(t, err)
+	})
+}

--- a/pkg/intel/metadata/fit/entry_txt_policy_record.go
+++ b/pkg/intel/metadata/fit/entry_txt_policy_record.go
@@ -1,0 +1,50 @@
+package fit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+type EntryTXTPolicyRecordDataInterface interface {
+	IsTXTEnabled() bool
+}
+
+type EntryTXTPolicyRecordDataIndexedIO struct {
+	IndexRegisterIOAddress uint16
+	DataRegisterIOAddress  uint16
+	AccessWidth            uint8
+	BitPosition            uint8
+	Index                  uint16
+}
+
+func (entryData *EntryTXTPolicyRecordDataIndexedIO) IsTXTEnabled() bool {
+	panic("not implemented")
+}
+
+type EntryTXTPolicyRecordDataFlatPointer uint64
+
+func (entryData EntryTXTPolicyRecordDataFlatPointer) TPMPolicyPointer() uint64 {
+	return uint64(entryData & 0x7fffffffffffffff)
+}
+func (entryData EntryTXTPolicyRecordDataFlatPointer) IsTXTEnabled() bool {
+	return entryData&0x8000000000000000 != 0
+}
+
+func (entry *EntryTXTPolicyRecord) Parse() (EntryTXTPolicyRecordDataInterface, error) {
+	switch entry.Headers.Version {
+	case 0:
+		ptr := binary.LittleEndian.Uint64(entry.DataBytes)
+		result := EntryTXTPolicyRecordDataFlatPointer(ptr)
+		return result, nil
+	case 1:
+		var dataParsed EntryTXTPolicyRecordDataIndexedIO
+		err := binary.Read(bytes.NewReader(entry.DataBytes), binary.LittleEndian, &dataParsed)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse EntryTXTPolicyRecordDataIndexedIO: %w", err)
+		}
+		return &dataParsed, nil
+	}
+
+	return nil, &ErrInvalidTXTPolicyRecordVersion{entry.Headers.Version}
+}

--- a/pkg/intel/metadata/fit/entry_txt_policy_record.go
+++ b/pkg/intel/metadata/fit/entry_txt_policy_record.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 )
 
+// EntryTXTPolicyRecordDataInterface is a parsed TXT Policy Record entry
 type EntryTXTPolicyRecordDataInterface interface {
 	IsTXTEnabled() bool
 }
 
+// EntryTXTPolicyRecordDataIndexedIO is a parsed TXT Policy Record entry of
+// version 1.
 type EntryTXTPolicyRecordDataIndexedIO struct {
 	IndexRegisterIOAddress uint16
 	DataRegisterIOAddress  uint16
@@ -18,19 +21,26 @@ type EntryTXTPolicyRecordDataIndexedIO struct {
 	Index                  uint16
 }
 
+// IsTXTEnabled returns true if TXT is enabled.
 func (entryData *EntryTXTPolicyRecordDataIndexedIO) IsTXTEnabled() bool {
 	panic("not implemented")
 }
 
+// EntryTXTPolicyRecordDataFlatPointer is a parsed TXT Policy Record entry
+// of version 0
 type EntryTXTPolicyRecordDataFlatPointer uint64
 
+// TPMPolicyPointer returns the TPM Policy pointer.
 func (entryData EntryTXTPolicyRecordDataFlatPointer) TPMPolicyPointer() uint64 {
 	return uint64(entryData & 0x7fffffffffffffff)
 }
+
+// IsTXTEnabled returns true if TXT is enabled.
 func (entryData EntryTXTPolicyRecordDataFlatPointer) IsTXTEnabled() bool {
 	return entryData&0x8000000000000000 != 0
 }
 
+// Parse parses TXT Policy Record entry
 func (entry *EntryTXTPolicyRecord) Parse() (EntryTXTPolicyRecordDataInterface, error) {
 	switch entry.Headers.Version {
 	case 0:

--- a/pkg/intel/metadata/fit/entry_type.go
+++ b/pkg/intel/metadata/fit/entry_type.go
@@ -1,0 +1,54 @@
+package fit
+
+// EntryType is a 7 bit field containing the type code for the component
+// registered in the FIT table.
+type EntryType uint8
+
+//noinspection GoSnakeCaseUsage
+const (
+	EntryTypeFITHeaderEntry              = EntryType(0x00)
+	EntryTypeMicrocodeUpdateEntry        = EntryType(0x01)
+	EntryTypeStartupACModuleEntry        = EntryType(0x02)
+	EntryTypeBIOSStartupModuleEntry      = EntryType(0x07)
+	EntryTypeTPMPolicyRecord             = EntryType(0x08)
+	EntryTypeBIOSPolicyRecord            = EntryType(0x09)
+	EntryTypeTXTPolicyRecord             = EntryType(0x0A)
+	EntryTypeKeyManifestRecord           = EntryType(0x0B)
+	EntryTypeBootPolicyManifest          = EntryType(0x0C)
+	EntryTypeCSESecureBoot               = EntryType(0x10)
+	EntryTypeFeaturePolicyDeliveryRecord = EntryType(0x2D)
+	EntryTypeJMP_DebugPolicy             = EntryType(0x2F)
+	EntryTypeSkip                        = EntryType(0x7F)
+)
+
+func (_type EntryType) String() string {
+	switch _type {
+	case EntryTypeFITHeaderEntry:
+		return "FIT_header_entry"
+	case EntryTypeMicrocodeUpdateEntry:
+		return "microcode_update_entry"
+	case EntryTypeStartupACModuleEntry:
+		return "startup_ACM_entry"
+	case EntryTypeBIOSStartupModuleEntry:
+		return "BIOS_startup_module_entry"
+	case EntryTypeTPMPolicyRecord:
+		return "TPM_policy_record"
+	case EntryTypeBIOSPolicyRecord:
+		return "BIOS_policy_record"
+	case EntryTypeTXTPolicyRecord:
+		return "TXT_policy_record"
+	case EntryTypeKeyManifestRecord:
+		return "key_manifest_record"
+	case EntryTypeBootPolicyManifest:
+		return "boot_policy_manifest"
+	case EntryTypeCSESecureBoot:
+		return "CSE_SecureBoot"
+	case EntryTypeFeaturePolicyDeliveryRecord:
+		return "feature_policy_delivery_record"
+	case EntryTypeJMP_DebugPolicy:
+		return "JMP__debug_policy"
+	case EntryTypeSkip:
+		return "skip_entry"
+	}
+	return "unknown_entry"
+}

--- a/pkg/intel/metadata/fit/entry_type.go
+++ b/pkg/intel/metadata/fit/entry_type.go
@@ -9,6 +9,7 @@ const (
 	EntryTypeFITHeaderEntry              = EntryType(0x00)
 	EntryTypeMicrocodeUpdateEntry        = EntryType(0x01)
 	EntryTypeStartupACModuleEntry        = EntryType(0x02)
+	EntryTypeDiagnosticACModuleEntry     = EntryType(0x03)
 	EntryTypeBIOSStartupModuleEntry      = EntryType(0x07)
 	EntryTypeTPMPolicyRecord             = EntryType(0x08)
 	EntryTypeBIOSPolicyRecord            = EntryType(0x09)
@@ -29,6 +30,8 @@ func (_type EntryType) String() string {
 		return "microcode_update_entry"
 	case EntryTypeStartupACModuleEntry:
 		return "startup_ACM_entry"
+	case EntryTypeDiagnosticACModuleEntry:
+		return "diagnostic_ACM_entry"
 	case EntryTypeBIOSStartupModuleEntry:
 		return "BIOS_startup_module_entry"
 	case EntryTypeTPMPolicyRecord:

--- a/pkg/intel/metadata/fit/entry_type.go
+++ b/pkg/intel/metadata/fit/entry_type.go
@@ -18,10 +18,11 @@ const (
 	EntryTypeBootPolicyManifest          = EntryType(0x0C)
 	EntryTypeCSESecureBoot               = EntryType(0x10)
 	EntryTypeFeaturePolicyDeliveryRecord = EntryType(0x2D)
-	EntryTypeJMP_DebugPolicy             = EntryType(0x2F)
+	EntryTypeJMPDebugPolicy              = EntryType(0x2F)
 	EntryTypeSkip                        = EntryType(0x7F)
 )
 
+// String implements fmt.Stringer
 func (_type EntryType) String() string {
 	switch _type {
 	case EntryTypeFITHeaderEntry:
@@ -48,8 +49,8 @@ func (_type EntryType) String() string {
 		return "CSE_SecureBoot"
 	case EntryTypeFeaturePolicyDeliveryRecord:
 		return "feature_policy_delivery_record"
-	case EntryTypeJMP_DebugPolicy:
-		return "JMP__debug_policy"
+	case EntryTypeJMPDebugPolicy:
+		return "JMP_debug_policy"
 	case EntryTypeSkip:
 		return "skip_entry"
 	}

--- a/pkg/intel/metadata/fit/errors.go
+++ b/pkg/intel/metadata/fit/errors.go
@@ -1,0 +1,42 @@
+package fit
+
+import (
+	"fmt"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/fit/consts"
+)
+
+type ErrACMInvalidKeySize struct {
+	ExpectedKeySize uint64
+	RealKeySize     uint64
+}
+
+func (err *ErrACMInvalidKeySize) Error() string {
+	return fmt.Sprintf("invalid key size, expected:%d, real:%d",
+		err.ExpectedKeySize, err.RealKeySize)
+}
+
+type ErrUnknownACMHeaderVersion struct {
+	ACHeaderVersion ACModuleHeaderVersion
+}
+
+func (err *ErrUnknownACMHeaderVersion) Error() string {
+	return fmt.Sprintf("unknown ACM header version: %v", err.ACHeaderVersion)
+}
+
+type ErrInvalidTXTPolicyRecordVersion struct {
+	EntryVersion EntryVersion
+}
+
+func (err *ErrInvalidTXTPolicyRecordVersion) Error() string {
+	return fmt.Sprintf("invalid TXT policy record version: %v", err.EntryVersion)
+}
+
+type ErrExpectedFITHeadersMagic struct {
+	Received []byte
+}
+
+func (err *ErrExpectedFITHeadersMagic) Error() string {
+	return fmt.Sprintf("string '%s' was expected as the Address value of the FIT header entry, but received: '%s'",
+		consts.FITHeadersMagic, err.Received)
+}

--- a/pkg/intel/metadata/fit/errors.go
+++ b/pkg/intel/metadata/fit/errors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/fit/consts"
 )
 
+// ErrACMInvalidKeySize means ACM entry has invalid key size
 type ErrACMInvalidKeySize struct {
 	ExpectedKeySize uint64
 	RealKeySize     uint64
@@ -16,6 +17,7 @@ func (err *ErrACMInvalidKeySize) Error() string {
 		err.ExpectedKeySize, err.RealKeySize)
 }
 
+// ErrUnknownACMHeaderVersion means ACM entry has invalid header version
 type ErrUnknownACMHeaderVersion struct {
 	ACHeaderVersion ACModuleHeaderVersion
 }
@@ -24,6 +26,7 @@ func (err *ErrUnknownACMHeaderVersion) Error() string {
 	return fmt.Sprintf("unknown ACM header version: %v", err.ACHeaderVersion)
 }
 
+// ErrInvalidTXTPolicyRecordVersion means TXT Policy entry has invalid version.
 type ErrInvalidTXTPolicyRecordVersion struct {
 	EntryVersion EntryVersion
 }
@@ -32,6 +35,8 @@ func (err *ErrInvalidTXTPolicyRecordVersion) Error() string {
 	return fmt.Sprintf("invalid TXT policy record version: %v", err.EntryVersion)
 }
 
+// ErrExpectedFITHeadersMagic means FIT magic string was not found where
+// it was expected.
 type ErrExpectedFITHeadersMagic struct {
 	Received []byte
 }
@@ -41,8 +46,9 @@ func (err *ErrExpectedFITHeadersMagic) Error() string {
 		consts.FITHeadersMagic, err.Received)
 }
 
+// ErrNotFound literally means "not found".
 type ErrNotFound struct{}
 
 func (ErrNotFound) Error() string {
-	return fmt.Sprintf("not found")
+	return "not found"
 }

--- a/pkg/intel/metadata/fit/errors.go
+++ b/pkg/intel/metadata/fit/errors.go
@@ -40,3 +40,9 @@ func (err *ErrExpectedFITHeadersMagic) Error() string {
 	return fmt.Sprintf("string '%s' was expected as the Address value of the FIT header entry, but received: '%s'",
 		consts.FITHeadersMagic, err.Received)
 }
+
+type ErrNotFound struct{}
+
+func (ErrNotFound) Error() string {
+	return fmt.Sprintf("not found")
+}

--- a/pkg/intel/metadata/fit/firmware.go
+++ b/pkg/intel/metadata/fit/firmware.go
@@ -1,0 +1,6 @@
+package fit
+
+type Firmware interface {
+	ImageBytes() []byte
+	PhysAddrToOffset(physAddr uint64) uint64
+}

--- a/pkg/intel/metadata/fit/firmware.go
+++ b/pkg/intel/metadata/fit/firmware.go
@@ -1,5 +1,6 @@
 package fit
 
+// Firmware is an abstraction from (*uefi.UEFI).
 type Firmware interface {
 	ImageBytes() []byte
 	PhysAddrToOffset(physAddr uint64) uint64

--- a/pkg/intel/metadata/fit/get_entries.go
+++ b/pkg/intel/metadata/fit/get_entries.go
@@ -1,0 +1,15 @@
+package fit
+
+import (
+	"fmt"
+)
+
+// GetEntries returns parsed FIT-entries
+func GetEntries(firmware []byte) ([]Entry, error) {
+	table, err := GetTable(firmware)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get FIT table: %w", err)
+	}
+
+	return table.GetEntries(firmware), nil
+}

--- a/pkg/intel/metadata/fit/get_entries_test.go
+++ b/pkg/intel/metadata/fit/get_entries_test.go
@@ -1,0 +1,44 @@
+package fit
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"encoding/base64"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	fitHeadersSampleBZ2, _ = base64.StdEncoding.DecodeString(
+		"QlpoOTFBWSZTWeqFfFEBARl/z/6cAAhAEAJAISIUAMAAYADAABBMUgACAI4AAAiwANiQkhUepkNBk0A0Gj0nqGMmmQMmhkGRpgRgVJRHqBPUGmBPQQB6mu/KQvlYVFwVWSqIERBhUJJEkSR53rKJMcLkAQB4VEmzyuIBAGNSSaLY2elZ4gEAapJc7BvQ6GAOz3zzwaWQh1wYvXevCRHSI64eYVYAyTeHJJpz9TxxkkkkkgAA+ewChlSjX5WsDQH+LuSKcKEh1Qr4og==")
+)
+
+func panicIfError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestGetEntries(t *testing.T) {
+	firmwareBytes, err := ioutil.ReadAll(bzip2.NewReader(bytes.NewReader(fitHeadersSampleBZ2)))
+	panicIfError(err)
+
+	entries, err := GetEntries(firmwareBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 27, len(entries))
+}
+
+// BenchmarkGetEntries-8             520621              2357 ns/op            2944 B/op         59 allocs/op
+func BenchmarkGetEntries(b *testing.B) {
+	firmwareBytes, err := ioutil.ReadAll(bzip2.NewReader(bytes.NewReader(fitHeadersSampleBZ2)))
+	panicIfError(err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = GetEntries(firmwareBytes)
+	}
+}

--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -1,0 +1,168 @@
+package fit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/9elements/converged-security-suite/v2/pkg/check"
+	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/fit/consts"
+	uefiConsts "github.com/9elements/converged-security-suite/v2/pkg/uefi/consts"
+)
+
+// Table is the FIT entry headers table (located by the "FIT Pointer")
+type Table []EntryHeaders
+
+// GetEntries returns parsed FIT-entries
+func (table Table) GetEntries(firmware []byte) (result []Entry) {
+	for _, headers := range table {
+		result = append(result, headers.GetEntry(firmware))
+	}
+	return
+}
+
+// ParseEntryHeadersFrom parses a single entry headers entry.
+func ParseEntryHeadersFrom(r io.Reader) (*EntryHeaders, error) {
+	entryHeaders := EntryHeaders{}
+	err := binary.Read(r, binary.LittleEndian, &entryHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse FIT entry headers: %w", err)
+	}
+
+	return &entryHeaders, nil
+}
+
+// ParseTable parses a FIT table from `b`.
+func ParseTable(b []byte) (Table, error) {
+	var result Table
+	r := bytes.NewReader(b)
+	for r.Len() > 0 {
+		entryHeaders, err := ParseEntryHeadersFrom(r)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse FIT headers table: %w", err)
+		}
+		result = append(result, *entryHeaders)
+	}
+	return result, nil
+}
+
+// GetPointerCoordinates returns the position of the FIT pointer within
+// the firmware.
+func GetPointerCoordinates(firmware []byte) (startIdx, endIdx uint64) {
+	startIdx = uint64(len(firmware)) - consts.FITPointerOffset
+	endIdx = startIdx + consts.FITPointerSize
+	return
+}
+
+// GetHeadersTableRange returns the starting and ending indexes of the FIT
+// headers table within the firmware image.
+func GetHeadersTableRange(firmware []byte) (startIdx, endIdx uint64, err error) {
+
+	/*
+		An example:
+		<image start>
+		...
+		01bb0000: 5f46 4954 5f20 2020 1b00 0000 0001 0000  _FIT_   ........ <--+
+		01bb0010: 80d5 e3ff 0000 0000 0000 0000 0001 0100  ................    |
+		01bb0020: 804d e4ff 0000 0000 0000 0000 0001 0100  .M..............    |
+		01bb0030: 80c5 e4ff 0000 0000 0000 0000 0001 0100  ................    |
+		01bb0040: 8035 e5ff 0000 0000 0000 0000 0001 0100  .5..............    |
+		01bb0050: ffff ffff 0000 0000 0000 0000 0001 7f00  ................    |
+		...                                                                    |
+		01bb0180: 7000 7100 0105 2a00 0000 0000 0000 0a00  p.q...*.........    |
+		01bb0190: 80c2 e5ff 0000 0000 4102 0000 0001 0b00  ........A.......    |
+		01bb01a0: 00b2 e5ff 0000 0000 df02 0000 0001 0c00  ................    |
+		01bb01b0: xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  xxxxxxxxxxxxxxxx    |
+		...                                                                    |
+		01ffffb0: xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  xxxxxxxxxxxxxxxx    |
+		01ffffc0: 0000 bbff 0000 0000 0000 0000 0000 0000  ................ >--+
+		01ffffd0: xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  xxxxxxxxxxxxxxxx
+		01ffffe0: xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  xxxxxxxxxxxxxxxx
+		01fffff0: xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx  xxxxxxxxxxxxxxxx
+		<image end>
+
+		So "0000 bbff" (LE: 0xffbb0000) is seems to be the fitPointer
+		(according to the specification).
+
+		Re-check:
+		 * fitPointerOffset <- 0x100000000 - 0xffbb0000 == 0x450000
+		 * headersStartIdx <- 0x2000000 - 0x450000 == 0x1bb0000
+		It's the correct value, yey!
+
+		The full procedure in more formal terms was:
+		 * fitPointerPointer <- 0x2000000 (firmwareLength) - 0x40 == 0x01ffffc0
+		 * fitPointer <- *fitPointerPointer == 0xffbb0000
+		 * fitPointerOffset <- 0x100000000 (const) - 0xffbb0000 == 0x450000
+		 * headersStartIdx <- 0x2000000 - 0x450000 == 0x1bb0000
+	*/
+
+	fitPointerStartIdx, fitPointerEndIdx := GetPointerCoordinates(firmware)
+
+	if err := check.BytesRange(firmware, int(fitPointerStartIdx), int(fitPointerEndIdx)); err != nil {
+		return 0, 0, fmt.Errorf("invalid fit pointer bytes range: %w", err)
+	}
+
+	fitPointerBytes := firmware[fitPointerStartIdx:fitPointerEndIdx]
+	fitPointerValue := binary.LittleEndian.Uint64(fitPointerBytes)
+	fitPointerOffset := uefiConsts.CalculateTailOffsetFromPhysAddr(fitPointerValue)
+	startIdx = uint64(len(firmware)) - fitPointerOffset
+
+	// OK, now we need to calculate the end of the headers...
+	//
+	// It's pretty easy. The first entry describes the table itself, and it's
+	// size is the size of the table. So let's just use it.
+
+	firstHeaderEndIdx := startIdx + uint64(entryHeadersSize)
+	if err = check.BytesRange(firmware, int(startIdx), int(firstHeaderEndIdx)); err != nil {
+		err = fmt.Errorf("invalid the first entry bytes range: %w", err)
+		return
+	}
+
+	tableMeta := EntryHeaders{}
+	err = binary.Read(bytes.NewReader(firmware[int(startIdx):firstHeaderEndIdx]), binary.LittleEndian, &tableMeta)
+	if err != nil {
+		err = fmt.Errorf("unable to parse the first entry: %w", err)
+		return
+	}
+
+	// Verify if the first entry contains "_FIT_  " as the address (as it is
+	// described by the point 1.2.2 of the specification).
+
+	var buf bytes.Buffer
+	err = binary.Write(&buf, binary.LittleEndian, tableMeta.Address)
+	if err != nil {
+		err = fmt.Errorf("unable to read the Address value of the FIT header entry: %w", err)
+		return
+	}
+	if bytes.Compare([]byte(consts.FITHeadersMagic), buf.Bytes()) != 0 {
+		err = &ErrExpectedFITHeadersMagic{Received: buf.Bytes()}
+		return
+	}
+
+	// OK, it's correct. Now we know the size of the table and we can
+	// parseHeaders it.
+
+	endIdx = startIdx + uint64(tableMeta.Size.Size())
+	if err = check.BytesRange(firmware, int(startIdx), int(endIdx)); err != nil {
+		err = fmt.Errorf("invalid entries bytes range: %w", err)
+		return
+	}
+
+	return
+}
+
+// GetTable returns the table of FIT entries of the firmware image.
+func GetTable(firmware []byte) (Table, error) {
+	startIdx, endIdx, err := GetHeadersTableRange(firmware)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := ParseTable(firmware[startIdx:endIdx])
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -167,7 +167,7 @@ func GetHeadersTableRange(firmware []byte) (startIdx, endIdx uint64, err error) 
 		err = fmt.Errorf("unable to read the Address value of the FIT header entry: %w", err)
 		return
 	}
-	if bytes.Compare([]byte(consts.FITHeadersMagic), buf.Bytes()) != 0 {
+	if !bytes.Equal([]byte(consts.FITHeadersMagic), buf.Bytes()) {
 		err = &ErrExpectedFITHeadersMagic{Received: buf.Bytes()}
 		return
 	}

--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -143,7 +143,7 @@ func GetHeadersTableRange(firmware []byte) (startIdx, endIdx uint64, err error) 
 	// OK, it's correct. Now we know the size of the table and we can
 	// parseHeaders it.
 
-	endIdx = startIdx + uint64(tableMeta.Size.Size())
+	endIdx = startIdx + uint64(tableMeta.DataSize())
 	if err = check.BytesRange(firmware, int(startIdx), int(endIdx)); err != nil {
 		err = fmt.Errorf("invalid entries bytes range: %w", err)
 		return

--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/9elements/converged-security-suite/v2/pkg/check"
 	"github.com/9elements/converged-security-suite/v2/pkg/intel/metadata/fit/consts"
@@ -20,6 +21,27 @@ func (table Table) GetEntries(firmware []byte) (result []Entry) {
 		result = append(result, headers.GetEntry(firmware))
 	}
 	return
+}
+
+// String prints the fit table in a tabular form
+func (table Table) String() string {
+	var s strings.Builder
+	// PrintFit prints the Firmware Interface Table in a tabular human readable form.
+	s.WriteString("Firmware Interface Table\n")
+	s.WriteString("------------------------\n")
+	fmt.Fprintf(&s, "%-25s | %-20s | %-8s | %-10s | %-15s | %-10s\n", "Type", "Address", "Size", "Version", "Checksum valid", "Checksum")
+	s.WriteString("-----------------------------------------------------------------------------------------------------\n")
+	for _, entry := range table {
+		fmt.Fprintf(&s, "%-25s | %-20s | %-8d | %-10s | %-15v | %-10d\n",
+			entry.Type().String(),
+			entry.Address.String(),
+			entry.Size.Uint32(),
+			entry.Version.String(),
+			entry.IsChecksumValid(),
+			entry.Checksum)
+	}
+	s.WriteString("\n")
+	return s.String()
 }
 
 // First returns the first entry headers with selected entry type

--- a/pkg/intel/metadata/fit/table.go
+++ b/pkg/intel/metadata/fit/table.go
@@ -22,6 +22,16 @@ func (table Table) GetEntries(firmware []byte) (result []Entry) {
 	return
 }
 
+// First returns the first entry headers with selected entry type
+func (table Table) First(entryType EntryType) *EntryHeaders {
+	for idx, headers := range table {
+		if headers.Type() == entryType {
+			return &table[idx]
+		}
+	}
+	return nil
+}
+
 // ParseEntryHeadersFrom parses a single entry headers entry.
 func ParseEntryHeadersFrom(r io.Reader) (*EntryHeaders, error) {
 	entryHeaders := EntryHeaders{}


### PR DESCRIPTION
Migrating Intel FIT parser from [converged-security-suite](https://github.com/9elements/converged-security-suite/tree/master/pkg/intel/metadata/fit).