### PR TITLE
fix(intel/fit): Do not panic on invalid addresses

### DIFF
--- a/pkg/intel/metadata/fit/entry.go
+++ b/pkg/intel/metadata/fit/entry.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/linuxboot/fiano/pkg/intel/metadata/fit/check"
 	"github.com/linuxboot/fiano/pkg/intel/metadata/fit/consts"
 	"github.com/xaionaro-go/bytesextra"
 )
@@ -253,6 +254,9 @@ func EntryDataSegmentCoordinates(entry Entry, firmware io.ReadSeeker) (uint64, u
 func sliceOrCopyBytesFrom(r io.ReadSeeker, startIdx, endIdx uint64) ([]byte, error) {
 	switch r := r.(type) {
 	case *bytesextra.ReadWriteSeeker:
+		if err := check.BytesRange(uint(len(r.Storage)), int(startIdx), int(endIdx)); err != nil {
+			return nil, err
+		}
 		return r.Storage[startIdx:endIdx], nil
 	default:
 		return copyBytesFrom(r, startIdx, endIdx)

--- a/pkg/intel/metadata/fit/get_entries_test.go
+++ b/pkg/intel/metadata/fit/get_entries_test.go
@@ -8,10 +8,12 @@ import (
 	"bytes"
 	"compress/bzip2"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -33,6 +35,30 @@ func TestGetEntries(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 27, len(entries))
+}
+
+func TestGetEntriesInvalidAddr(t *testing.T) {
+	sampleEntries := getSampleEntries(t)
+	for _, entry := range sampleEntries[1:] {
+		entry.GetEntryBase().Headers.Address = 2<<32 + 1 // overflow
+		entry.GetEntryBase().DataSegmentBytes = nil
+	}
+
+	dummyImage := make([]byte, 1024)
+	err := sampleEntries.Inject(dummyImage, 512)
+	require.NoError(t, err)
+
+	// There should be no panic, and the errors should be inside entry headers.
+	entries, err := GetEntries(dummyImage)
+	require.NoError(t, err)
+	for _, entry := range entries[1:] {
+		switch entry := entry.(type) {
+		case *EntrySkip:
+			continue
+		default:
+			require.Contains(t, fmt.Sprintf("%v", entry.GetEntryBase().HeadersErrors), "index")
+		}
+	}
 }
 
 // BenchmarkGetEntries-8             520621              2357 ns/op            2944 B/op         59 allocs/op


### PR DESCRIPTION
If a FIT entry contains an invalid address, it causes a panic. Fixing it.