### PR TITLE
fix(utk): Correctly detect the end of the free area

### DIFF
--- a/pkg/visitors/createfv.go
+++ b/pkg/visitors/createfv.go
@@ -53,7 +53,7 @@ func (v *CreateFV) Visit(f uefi.Firmware) error {
 		if v.AbsOffset < offset {
 			return fmt.Errorf("cannot create FV at %#x, BIOS region starts at %#x", v.AbsOffset, offset)
 		}
-		if v.AbsOffset+v.Size >= end {
+		if v.AbsOffset+v.Size > end {
 			return fmt.Errorf("cannot create FV ending at %#x (%#x + %#x), BIOS region ends at %#x", v.AbsOffset+v.Size, v.AbsOffset, v.Size, end)
 		}
 


### PR DESCRIPTION
On attempts to create a volume which ends in the end of
the BIOS region it returns an error:

    dd if=/dev/zero of=/tmp/image bs=1K count=64
    utk /tmp/image create-fv $((32 * 1024)) $((32 * 1024)) "61C0F511-A691-4F54-974F-B9A42172CE53"
    2022/01/17 20:47:10 [fiano][FATAL] cannot create FV ending at 0x10000 (0x8000 + 0x8000), BIOS region ends at 0x10000

Fixing it.