### PR TITLE
Feature/utk/insert pad file

### DIFF
--- a/pkg/visitors/insert.go
+++ b/pkg/visitors/insert.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"strings"
 
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
@@ -18,48 +19,61 @@ type InsertType int
 
 // Insert Types
 const (
-	// InsertPad* inserts a pad file.
-	// non-Pad Insert* inserts a regular file.
+
+	// == Deprectated ==
+
+	// These first two specify a firmware volume.
 
 	// InsertFront inserts a file at the beginning of the firmware volume,
 	// which is specified by 1) FVname GUID, or (File GUID/File name) of a file
 	// inside that FV.
 	InsertFront InsertType = iota
-	InsertPadFront
 	// InsertEnd inserts a file at the end of the specified firmware volume.
 	InsertEnd
-	InsertPadEnd
 
 	// These two specify a File to insert before or after
 	// InsertAfter inserts after the specified file,
 	// which is specified by a File GUID or File name.
 	InsertAfter
-	InsertPadAfter
 	// InsertBefore inserts before the specified file.
 	InsertBefore
-	InsertPadBefore
 	// InsertDXE inserts into the Dxe Firmware Volume. This works by searching
 	// for the DxeCore first to identify the Dxe Firmware Volume.
 	InsertDXE
+
+	// == Not deprecated ==
 
 	// ReplaceFFS replaces the found file with the new FFS. This is used
 	// as a shortcut for remove and insert combined, but also when we want to make
 	// sure that the starting offset of the new file is the same as the old.
 	ReplaceFFS
 	// TODO: Add InsertIn
+
+	// Insert is generalization of all Insert* above. Arguments:
+	// * The first argument specifies the type of what to insert (possible values: "file" or "pad_file")
+	// * The second argument specifies the content of what to insert:
+	//     - If the first argument is "file" then a path to the file content is expected.
+	//     - If the first argument is "pad_file" then the size is expected.
+	// * The third argument specifies the preposition of where to insert to (possible values: "front", "end", "after", "before").
+	// * The forth argument specifies the preposition object of where to insert to. It could be FV_or_File GUID_or_name.
+	//   For example combination "end 5C60F367-A505-419A-859E-2A4FF6CA6FE5" means to insert to the end of volume
+	//   "5C60F367-A505-419A-859E-2A4FF6CA6FE5".
+	//
+	// A complete example: "pad_file 256 after FC510EE7-FFDC-11D4-BD41-0080C73C8881" means to insert a pad file
+	// of size 256 bytes after file with GUID "FC510EE7-FFDC-11D4-BD41-0080C73C8881".
+	Insert
 )
 
 var insertTypeNames = map[InsertType]string{
-	InsertFront:     "insert_front",
-	InsertPadFront:  "insert_pad_front",
-	InsertEnd:       "insert_end",
-	InsertPadEnd:    "insert_pad_end",
-	InsertAfter:     "insert_after",
-	InsertPadAfter:  "insert_pad_after",
-	InsertBefore:    "insert_before",
-	InsertPadBefore: "insert_pad_before",
-	InsertDXE:       "insert_dxe",
-	ReplaceFFS:      "replace_ffs",
+	Insert:     "insert",
+	ReplaceFFS: "replace_ffs",
+
+	// Deprecated:
+	InsertFront:  "insert_front",
+	InsertEnd:    "insert_end",
+	InsertAfter:  "insert_after",
+	InsertBefore: "insert_before",
+	InsertDXE:    "insert_dxe",
 }
 
 // String creates a string representation for the insert type.
@@ -70,8 +84,90 @@ func (i InsertType) String() string {
 	return "UNKNOWN"
 }
 
-// Insert inserts a firmware file into an FV
-type Insert struct {
+// InsertWhatType defines the type of inserting object
+type InsertWhatType int
+
+const (
+	InsertWhatTypeUndefined = InsertWhatType(iota)
+	InsertWhatTypeFile
+	InsertWhatTypePadFile
+
+	EndOfInsertWhatType
+)
+
+// String implements fmt.Stringer.
+func (t InsertWhatType) String() string {
+	switch t {
+	case InsertWhatTypeUndefined:
+		return "undefined"
+	case InsertWhatTypeFile:
+		return "file"
+	case InsertWhatTypePadFile:
+		return "pad_file"
+	}
+	return fmt.Sprintf("unknown_%d", t)
+}
+
+// ParseInsertWhatType converts a string to InsertWhatType
+func ParseInsertWhatType(s string) InsertWhatType {
+	// TODO: it is currently O(n), optimize
+
+	s = strings.Trim(strings.ToLower(s), " \t")
+	for t := InsertWhatTypeUndefined; t < EndOfInsertWhatType; t++ {
+		if t.String() == s {
+			return t
+		}
+	}
+	return InsertWhatTypeUndefined
+}
+
+// InsertWherePreposition defines the type of inserting object
+type InsertWherePreposition int
+
+const (
+	InsertWherePrepositionUndefined = InsertWherePreposition(iota)
+	InsertWherePrepositionFront
+	InsertWherePrepositionEnd
+	InsertWherePrepositionAfter
+	InsertWherePrepositionBefore
+
+	EndOfInsertWherePreposition
+)
+
+// String implements fmt.Stringer.
+func (p InsertWherePreposition) String() string {
+	switch p {
+	case InsertWherePrepositionUndefined:
+		return "undefined"
+	case InsertWherePrepositionFront:
+		return "front"
+	case InsertWherePrepositionEnd:
+		return "end"
+	case InsertWherePrepositionAfter:
+		return "after"
+	case InsertWherePrepositionBefore:
+		return "before"
+	}
+	return fmt.Sprintf("unknown_%d", p)
+}
+
+// ParseInsertWherePreposition converts a string to InsertWherePreposition
+func ParseInsertWherePreposition(s string) InsertWherePreposition {
+	// TODO: it is currently O(n), optimize
+
+	s = strings.Trim(strings.ToLower(s), " \t")
+	for t := InsertWherePrepositionUndefined; t < EndOfInsertWherePreposition; t++ {
+		if t.String() == s {
+			return t
+		}
+	}
+	return InsertWherePrepositionUndefined
+}
+
+// Inserter inserts a firmware file into an FV
+type Inserter struct {
+	// TODO: use InsertWherePreposition to define the location, instead of InsertType
+
 	// Input
 	Predicate func(f uefi.Firmware) bool
 	NewFile   *uefi.File
@@ -82,7 +178,7 @@ type Insert struct {
 }
 
 // Run wraps Visit and performs some setup and teardown tasks.
-func (v *Insert) Run(f uefi.Firmware) error {
+func (v *Inserter) Run(f uefi.Firmware) error {
 	// First run "find" to generate a position to insert into.
 	find := Find{
 		Predicate: v.Predicate,
@@ -120,21 +216,22 @@ func (v *Insert) Run(f uefi.Firmware) error {
 }
 
 // Visit applies the Insert visitor to any Firmware type.
-func (v *Insert) Visit(f uefi.Firmware) error {
+func (v *Inserter) Visit(f uefi.Firmware) error {
 	switch f := f.(type) {
 	case *uefi.FirmwareVolume:
 		for i := 0; i < len(f.Files); i++ {
 			if f.Files[i] == v.FileMatch {
+				// TODO: use InsertWherePreposition to define the location, instead of InsertType
 				switch v.InsertType {
-				case InsertFront, InsertPadFront:
+				case InsertFront:
 					f.Files = append([]*uefi.File{v.NewFile}, f.Files...)
 				case InsertDXE:
 					fallthrough
-				case InsertEnd, InsertPadEnd:
+				case InsertEnd:
 					f.Files = append(f.Files, v.NewFile)
-				case InsertAfter, InsertPadAfter:
+				case InsertAfter:
 					f.Files = append(f.Files[:i+1], append([]*uefi.File{v.NewFile}, f.Files[i+1:]...)...)
-				case InsertBefore, InsertPadBefore:
+				case InsertBefore:
 					f.Files = append(f.Files[:i], append([]*uefi.File{v.NewFile}, f.Files[i:]...)...)
 				case ReplaceFFS:
 					f.Files = append(f.Files[:i], append([]*uefi.File{v.NewFile}, f.Files[i+1:]...)...)
@@ -147,7 +244,21 @@ func (v *Insert) Visit(f uefi.Firmware) error {
 	return f.ApplyChildren(v)
 }
 
-func genInsertCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
+func parseFile(filePath string) (*uefi.File, error) {
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file '%s': %w", filePath, err)
+	}
+
+	file, err := uefi.NewFile(fileBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse file '%s': %w", filePath, err)
+	}
+
+	return file, nil
+}
+
+func genInsertRegularFileCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
 	return func(args []string) (uefi.Visitor, error) {
 		var pred FindPredicate
 		var err error
@@ -164,18 +275,13 @@ func genInsertCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
 			filename = args[1]
 		}
 
-		newFileBuf, err := ioutil.ReadFile(filename)
+		file, err := parseFile(filename)
 		if err != nil {
-			return nil, err
-		}
-		// Parse the file.
-		file, err := uefi.NewFile(newFileBuf)
-		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to parse file '%s': %w", args[1], err)
 		}
 
 		// Insert File.
-		return &Insert{
+		return &Inserter{
 			Predicate:  pred,
 			NewFile:    file,
 			InsertType: iType,
@@ -183,51 +289,82 @@ func genInsertCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
 	}
 }
 
-func genInsertPadCLI(iType InsertType) func(args []string) (uefi.Visitor, error) {
+func genInsertFileCLI() func(args []string) (uefi.Visitor, error) {
 	return func(args []string) (uefi.Visitor, error) {
-		pred, err := FindFileFVPredicate(args[0])
+		whatType := ParseInsertWhatType(args[0])
+		if whatType == InsertWhatTypeUndefined {
+			return nil, fmt.Errorf("unknown what-type: '%s'", args[0])
+		}
+
+		var file *uefi.File
+		switch whatType {
+		case InsertWhatTypeFile:
+			var err error
+			file, err = parseFile(args[1])
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse file '%s': %w", args[1], err)
+			}
+		case InsertWhatTypePadFile:
+			padSize, err := strconv.ParseUint(args[1], 0, 64)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse pad file size '%s': %w", args[1], err)
+			}
+			file, err = uefi.CreatePadFile(padSize)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create a pad file of size %d: %w", padSize, err)
+			}
+		default:
+			return nil, fmt.Errorf("what-type '%s' is not supported, yet", whatType)
+		}
+
+		wherePreposition := ParseInsertWherePreposition(args[2])
+		if wherePreposition == InsertWherePrepositionUndefined {
+			return nil, fmt.Errorf("unknown where-preposition: '%s'", args[2])
+		}
+
+		pred, err := FindFileFVPredicate(args[3])
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse the predicate parameters '%s': %w", args[0], err)
 		}
 
-		padSize, err := strconv.ParseUint(args[1], 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse pad file size '%s': %w", args[1], err)
-		}
-
-		file, err := uefi.CreatePadFile(padSize)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create a pad file of size %d: %w", padSize, err)
+		// TODO: use InsertWherePreposition to define the location, instead of InsertType
+		var insertType InsertType
+		switch wherePreposition {
+		case InsertWherePrepositionFront:
+			insertType = InsertFront
+		case InsertWherePrepositionEnd:
+			insertType = InsertEnd
+		case InsertWherePrepositionAfter:
+			insertType = InsertAfter
+		case InsertWherePrepositionBefore:
+			insertType = InsertBefore
+		default:
+			return nil, fmt.Errorf("where-preposition '%s' is not supported, yet", wherePreposition)
 		}
 
 		// Insert File.
-		return &Insert{
-			Predicate:  pred,
-			NewFile:    file,
-			InsertType: iType,
+		return &Inserter{
+			Predicate: pred,
+			NewFile:   file,
+			// TODO: use InsertWherePreposition to define the location, instead of InsertType
+			InsertType: insertType,
 		}, nil
 	}
 }
 
 func init() {
-	RegisterCLI(insertTypeNames[InsertFront],
-		"insert a file at the beginning of a firmware volume", 2, genInsertCLI(InsertFront))
-	RegisterCLI(insertTypeNames[InsertEnd],
-		"insert a file at the end of a firmware volume", 2, genInsertCLI(InsertEnd))
-	RegisterCLI(insertTypeNames[InsertDXE],
-		"insert a file at the end of the DXE firmware volume", 1, genInsertCLI(InsertDXE))
-	RegisterCLI(insertTypeNames[InsertAfter],
-		"insert a file after another file", 2, genInsertCLI(InsertAfter))
-	RegisterCLI(insertTypeNames[InsertBefore],
-		"insert a file before another file", 2, genInsertCLI(InsertBefore))
+	RegisterCLI(insertTypeNames[Insert],
+		"insert a file", 4, genInsertFileCLI())
 	RegisterCLI(insertTypeNames[ReplaceFFS],
-		"replace a file with another file", 2, genInsertCLI(ReplaceFFS))
-	RegisterCLI(insertTypeNames[InsertPadFront],
-		"insert a pad file at the beginning of a firmware volume", 2, genInsertPadCLI(InsertFront))
-	RegisterCLI(insertTypeNames[InsertPadEnd],
-		"insert a pad file at the end of a firmware volume", 2, genInsertPadCLI(InsertEnd))
-	RegisterCLI(insertTypeNames[InsertPadAfter],
-		"insert a pad file after another file", 2, genInsertPadCLI(InsertPadAfter))
-	RegisterCLI(insertTypeNames[InsertPadBefore],
-		"insert a pad file before another file", 2, genInsertPadCLI(InsertPadBefore))
+		"replace a file with another file", 2, genInsertRegularFileCLI(ReplaceFFS))
+	RegisterCLI(insertTypeNames[InsertFront],
+		"(deprecated) insert a file at the beginning of a firmware volume", 2, genInsertRegularFileCLI(InsertFront))
+	RegisterCLI(insertTypeNames[InsertEnd],
+		"(deprecated) insert a file at the end of a firmware volume", 2, genInsertRegularFileCLI(InsertEnd))
+	RegisterCLI(insertTypeNames[InsertDXE],
+		"(deprecated) insert a file at the end of the DXE firmware volume", 1, genInsertRegularFileCLI(InsertDXE))
+	RegisterCLI(insertTypeNames[InsertAfter],
+		"(deprecated) insert a file after another file", 2, genInsertRegularFileCLI(InsertAfter))
+	RegisterCLI(insertTypeNames[InsertBefore],
+		"(deprecated) insert a file before another file", 2, genInsertRegularFileCLI(InsertBefore))
 }

--- a/pkg/visitors/insert_test.go
+++ b/pkg/visitors/insert_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
-func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUID guid.GUID) (*Insert, error) {
+func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUID guid.GUID) (*Inserter, error) {
 	file, err := ioutil.ReadFile("../../integration/roms/testfile.ffs")
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUI
 	} else {
 		pred = FindFileGUIDPredicate(testGUID)
 	}
-	insert := &Insert{
+	insert := &Inserter{
 		Predicate:  pred,
 		NewFile:    ffs,
 		InsertType: insertType,

--- a/pkg/visitors/insert_test.go
+++ b/pkg/visitors/insert_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/linuxboot/fiano/pkg/uefi"
 )
 
-func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUID guid.GUID) (*Inserter, error) {
+func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUID guid.GUID) (*Insert, error) {
 	file, err := ioutil.ReadFile("../../integration/roms/testfile.ffs")
 	if err != nil {
 		t.Fatal(err)
@@ -25,12 +25,12 @@ func testRunInsert(t *testing.T, f uefi.Firmware, insertType InsertType, testGUI
 	}
 	// Apply the visitor.
 	var pred FindPredicate
-	if insertType == InsertDXE {
+	if insertType == InsertTypeDXE {
 		pred = FindFileTypePredicate(uefi.FVFileTypeDXECore)
 	} else {
 		pred = FindFileGUIDPredicate(testGUID)
 	}
-	insert := &Inserter{
+	insert := &Insert{
 		Predicate:  pred,
 		NewFile:    ffs,
 		InsertType: insertType,
@@ -44,11 +44,11 @@ func TestInsert(t *testing.T) {
 		name string
 		InsertType
 	}{
-		{InsertFront.String(), InsertFront},
-		{InsertEnd.String(), InsertEnd},
-		{InsertAfter.String(), InsertAfter},
-		{InsertBefore.String(), InsertBefore},
-		{InsertDXE.String(), InsertDXE},
+		{InsertTypeFront.String(), InsertTypeFront},
+		{InsertTypeEnd.String(), InsertTypeEnd},
+		{InsertTypeAfter.String(), InsertTypeAfter},
+		{InsertTypeBefore.String(), InsertTypeBefore},
+		{InsertTypeDXE.String(), InsertTypeDXE},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestDoubleFindInsert(t *testing.T) {
 		name string
 		InsertType
 	}{
-		{"insert_after double result", InsertAfter},
+		{"insert_after double result", InsertTypeAfter},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -107,7 +107,7 @@ func TestNoFindInsert(t *testing.T) {
 		name string
 		InsertType
 	}{
-		{"insert_after no file", InsertAfter},
+		{"insert_after no file", InsertTypeAfter},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Adding a feature to insert padding files.
```
xaionaro@void:~/go/src/github.com/linuxboot/fiano$ go run ./cmds/utk/ -erase-polarity=0xFF /tmp/image \
 create-fv $((32 * 1024)) $((32 * 1024-16)) "61C0F511-A691-4F54-974F-B9A42172CE53" \
 insert_pad_end "61C0F511-A691-4F54-974F-B9A42172CE53" $((32 * 1024-256)) \
 save /tmp/new_image
xaionaro@void:~/go/src/github.com/linuxboot/fiano$ pcr0tool printnodes -as-tree /tmp/new_image
________-____-____-____-____________ *uefi.BIOSRegion  0 65536
  ________-____-____-____-____________ *uefi.BIOSPadding  0 0
  61C0F511-A691-4F54-974F-B9A42172CE53 *uefi.FirmwareVolume  32768 32752
    FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF *uefi.File  32888 32512
  ________-____-____-____-____________ *uefi.BIOSPadding  0 0
```