### PR TITLE
cmds/cbfs: print usage on argument error

### DIFF
--- a/cmds/cbfs/cbfs.go
+++ b/cmds/cbfs/cbfs.go
@@ -24,7 +24,7 @@ func main() {
 
 	a := flag.Args()
 	if len(a) != 2 {
-		log.Fatal("arg count")
+		log.Fatal("Usage: cbfs <firmware-file> <json,list>")
 	}
 
 	i, err := cbfs.Open(a[0])


### PR DESCRIPTION
Signed-off-by: Daniel Maslowski <info@orangecms.org>