### PR TITLE
[intel/fit] Fix ACMv3 headers parser

### DIFF
--- a/pkg/intel/metadata/fit/ent_startup_ac_module_entry.go
+++ b/pkg/intel/metadata/fit/ent_startup_ac_module_entry.go
@@ -106,11 +106,15 @@ type ACModuleHeaderVersion uint32
 
 const (
 	// ACHeaderVersion0 is version "0.0 – for SINIT ACM before 2017"
-	ACHeaderVersion0 = ACModuleHeaderVersion(0x0000)
+	ACHeaderVersion0 = ACModuleHeaderVersion(0x00000000)
 
 	// ACHeaderVersion3 is version "3.0 – for SINIT ACM of converge of BtG and TXT"
-	ACHeaderVersion3 = ACModuleHeaderVersion(0x0300)
+	ACHeaderVersion3 = ACModuleHeaderVersion(0x00030000)
 )
+
+func (ver ACModuleHeaderVersion) GoString() string {
+	return fmt.Sprintf("0x%08X", ver)
+}
 
 // ACChipsetID defines the module release identifier
 type ACChipsetID uint16

--- a/pkg/intel/metadata/fit/errors.go
+++ b/pkg/intel/metadata/fit/errors.go
@@ -27,7 +27,7 @@ type ErrUnknownACMHeaderVersion struct {
 }
 
 func (err *ErrUnknownACMHeaderVersion) Error() string {
-	return fmt.Sprintf("unknown ACM header version: %v", err.ACHeaderVersion)
+	return fmt.Sprintf("unknown ACM header version: %#v", err.ACHeaderVersion)
 }
 
 // ErrInvalidTXTPolicyRecordVersion means TXT Policy entry has invalid version.


### PR DESCRIPTION
HeaderVersion field is 32bits long, not 16bits long. The initial constant is a typo. Fixing it.