### PR TITLE
pkg/uefi: fix section buffer

### DIFF
--- a/pkg/uefi/file.go
+++ b/pkg/uefi/file.go
@@ -450,10 +450,12 @@ func NewFile(buf []byte) (*File, error) {
 
 	if ReadOnly {
 		f.buf = buf[:f.Header.ExtendedSize]
+		log.Errorf("Readonly, buf size %v for %v\n  ( %v )\n\n", f.Header.ExtendedSize, f.Type, f.Header.GUID)
 	} else {
 		// Copy out the buffer.
 		newBuf := buf[:f.Header.ExtendedSize]
 		f.buf = make([]byte, f.Header.ExtendedSize)
+		log.Errorf("Writable, buf size %v for %v\n  ( %v )\n\n", f.Header.ExtendedSize, f.Type, f.Header.GUID)
 		copy(f.buf, newBuf)
 	}
 
@@ -471,6 +473,9 @@ func NewFile(buf []byte) (*File, error) {
 	if _, ok := SupportedFiles[f.Header.Type]; !ok {
 		return &f, nil
 	}
+	// FIXME: To create a section, you need to know the correct buffer size in
+	// advance. However, the f.buf buffer can be too small, and its size is only
+	// checked in `NewSection`, which expects the correct size. That won't work.
 	for i, offset := 0, f.DataOffset; offset < f.Header.ExtendedSize; i++ {
 		s, err := NewSection(f.buf[offset:], i)
 		if err != nil {


### PR DESCRIPTION
Found errors with buffer handling when @zaolin tried to load an image from a SuperMicro board into Fiedka.

This is WIP; @zaolin will take over. Good luck! :four_leaf_clover: 