### PR TITLE
pkg/intel: Add support for Intel microcode files

### DIFF
--- a/cmds/microcode/microcode.go
+++ b/cmds/microcode/microcode.go
@@ -1,0 +1,42 @@
+// Copyright 2023 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/linuxboot/fiano/pkg/intel/microcode"
+	flag "github.com/spf13/pflag"
+)
+
+func main() {
+	flag.Parse()
+
+	a := flag.Args()
+	if len(a) != 1 {
+		log.Fatal("Usage: microcode <microcode-file>")
+	}
+
+	f, err := os.Open(a[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	b := bufio.NewReader(f)
+
+	for {
+		_, err = b.Peek(microcode.DefaultTotalSize)
+		if err != nil {
+			break
+		}
+		m, err := microcode.ParseIntelMicrocode(b)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(m)
+	}
+}

--- a/pkg/intel/microcode/microcode.go
+++ b/pkg/intel/microcode/microcode.go
@@ -1,0 +1,167 @@
+// Copyright 2023 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package microcode
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	DefaultDatasize  = 2000
+	DefaultTotalSize = 2048
+)
+
+type Microcode struct {
+	Header
+	Data               []byte
+	ExtSigTable        ExtendedSigTable
+	ExtendedSignatures []ExtendedSignature
+}
+
+func (m *Microcode) String() string {
+	s := fmt.Sprintf("sig=0x%x, pf=0x%x, rev=0x%x, total size=0x%x, date = %04x-%02x-%02x",
+		m.HeaderProcessorSignature, m.HeaderProcessorFlags, m.HeaderRevision,
+		getTotalSize(m.Header), m.HeaderDate&0xffff, m.HeaderDate>>24, (m.HeaderDate>>16)&0xff)
+	if len(m.ExtendedSignatures) > 0 {
+		s += "\n"
+	}
+	for i := range m.ExtendedSignatures {
+		s += fmt.Sprintf("Extended signature[%d]: %s\n", i, m.ExtendedSignatures[i].String())
+	}
+	return s
+}
+
+type Header struct {
+	HeaderVersion            uint32 // must be 0x1
+	HeaderRevision           uint32
+	HeaderDate               uint32 // packed BCD, MMDDYYYY
+	HeaderProcessorSignature uint32
+	HeaderChecksum           uint32
+	HeaderLoaderRevision     uint32
+	HeaderProcessorFlags     uint32
+	HeaderDataSize           uint32 // 0 means 2000
+	HeaderTotalSize          uint32 // 0 means 2048
+	Reserved1                [3]uint32
+}
+
+type ExtendedSignature struct {
+	Signature      uint32
+	ProcessorFlags uint32
+	Checksum       uint32
+}
+
+func (e *ExtendedSignature) String() string {
+	return fmt.Sprintf("sig=0x%x, pf=0x%x", e.Signature, e.ProcessorFlags)
+}
+
+type ExtendedSigTable struct {
+	Count    uint32
+	Checksum uint32
+	Reserved [3]uint32
+}
+
+func getTotalSize(h Header) uint32 {
+	if h.HeaderDataSize > 0 {
+		return h.HeaderTotalSize
+	} else {
+		return DefaultTotalSize
+	}
+}
+
+func getDataSize(h Header) uint32 {
+	if h.HeaderDataSize > 0 {
+		return h.HeaderDataSize
+	} else {
+		return DefaultDatasize
+	}
+}
+
+// ParseIntelMicrocode parses the Intel microcode update
+func ParseIntelMicrocode(r io.Reader) (*Microcode, error) {
+	var m Microcode
+
+	if err := binary.Read(r, binary.LittleEndian, &m.Header); err != nil {
+		return nil, fmt.Errorf("Failed to read header: %v", err)
+	}
+
+	// Sanitychecks
+	if getTotalSize(m.Header) < getDataSize(m.Header)+uint32(binary.Size(Header{})) {
+		return nil, fmt.Errorf("Bad data file size")
+	}
+	if m.HeaderLoaderRevision != 1 || m.HeaderVersion != 1 {
+		return nil, fmt.Errorf("Invalid version or revision")
+	}
+	if getDataSize(m.Header)%4 > 0 {
+		return nil, fmt.Errorf("Data size not 32bit aligned")
+	}
+	if getTotalSize(m.Header)%4 > 0 {
+		return nil, fmt.Errorf("Total size not 32bit aligned")
+	}
+	// Read data
+	m.Data = make([]byte, getDataSize(m.Header))
+	if err := binary.Read(r, binary.LittleEndian, &m.Data); err != nil {
+		return nil, fmt.Errorf("Failed to read data: %v", err)
+	}
+
+	// Calculcate checksum
+	buf := bytes.NewBuffer([]byte{})
+	buf.Grow(int(getDataSize(m.Header)) + binary.Size(Header{}))
+	_ = binary.Write(buf, binary.LittleEndian, &m.Header)
+	_ = binary.Write(buf, binary.LittleEndian, &m.Data)
+
+	var checksum uint32
+	for {
+		var data uint32
+		if err := binary.Read(buf, binary.LittleEndian, &data); err != nil {
+			break
+		}
+		checksum += data
+	}
+	if checksum != 0 {
+		return nil, fmt.Errorf("Checksum is not null: %#x", checksum)
+	}
+
+	if getTotalSize(m.Header) <= getDataSize(m.Header)+uint32(binary.Size(Header{})) {
+		return &m, nil
+	}
+
+	// Read extended header
+	if err := binary.Read(r, binary.LittleEndian, &m.ExtSigTable); err != nil {
+		return nil, fmt.Errorf("Failed to read extended sig table: %v", err)
+	}
+	for i := uint32(0); i < m.ExtSigTable.Count; i++ {
+		var signature ExtendedSignature
+		if err := binary.Read(r, binary.LittleEndian, &signature); err != nil {
+			return nil, fmt.Errorf("Failed to read extended signature: %v", err)
+		}
+		m.ExtendedSignatures = append(m.ExtendedSignatures, signature)
+	}
+
+	// Calculcate checksum
+	buf = bytes.NewBuffer([]byte{})
+	buf.Grow(binary.Size(ExtendedSigTable{}) +
+		int(m.ExtSigTable.Count)*binary.Size(ExtendedSignature{}))
+	_ = binary.Write(buf, binary.LittleEndian, &m.ExtSigTable)
+	for i := uint32(0); i < m.ExtSigTable.Count; i++ {
+		_ = binary.Write(buf, binary.LittleEndian, &m.ExtendedSignatures[i])
+	}
+
+	checksum = 0
+	for {
+		var data uint32
+		if err := binary.Read(buf, binary.LittleEndian, &data); err != nil {
+			break
+		}
+		checksum += data
+	}
+	if checksum != 0 {
+		return nil, fmt.Errorf("Extended header checksum is not null: %#x", checksum)
+	}
+
+	return &m, nil
+}

--- a/pkg/intel/microcode/microcode_test.go
+++ b/pkg/intel/microcode/microcode_test.go
@@ -1,0 +1,168 @@
+// Copyright 2023 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package microcode
+
+import (
+	"bytes"
+	"testing"
+)
+
+var (
+	testMicrocode         = []byte("\x01\x00\x00\x00\x24\x04\x00\x00\x22\x20\x19\x09\xa3\x06\x09\x00\x5d\xd4\xdd\xf6\x01\x00\x00\x00\x80\x00\x00\x00\x04\x00\x00\x00\x34\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	testMicrocodeExtTable = []byte("\x01\x00\x00\x00\x24\x04\x00\x00\x22\x20\x19\x09\xa3\x06\x09\x00\x31\xd4\xdd\xf6\x01\x00\x00\x00\x80\x00\x00\x00\x04\x00\x00\x00\x60\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x06\x5a\x21\x95\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa3\x06\x09\x00\x80\x00\x00\x00\xd9\x4b\x66\xb5\xa4\x06\x09\x00\x80\x00\x00\x00\xd8\x4b\x66\xb5")
+)
+
+func TestParseMicrocodeExtTable(t *testing.T) {
+	var m *Microcode
+	var err error
+
+	if m, err = ParseIntelMicrocode(bytes.NewBuffer(testMicrocodeExtTable)); err != nil {
+		t.Errorf("Failed to parse microcode %v", err)
+		return
+	}
+	if m.HeaderProcessorFlags != 0x80 {
+		t.Errorf("Got microcode processor flags %#x, expected %#x", m.HeaderProcessorFlags, 0x80)
+	}
+	if m.HeaderDataSize != 4 {
+		t.Errorf("Got microcode data size %#x, expected %#x", m.HeaderDataSize, 4)
+	}
+	if m.HeaderTotalSize != 0x60 {
+		t.Errorf("Got microcode total size %#x, expected %#x", m.HeaderTotalSize, 0x60)
+	}
+	if m.HeaderProcessorSignature != 0x906a3 {
+		t.Errorf("Got microcode processor signature %#x, expected %#x", m.HeaderProcessorSignature, 0x906a3)
+	}
+	if m.HeaderDate != 0x9192022 {
+		t.Errorf("Got microcode date %#x, expected %#x", m.HeaderDate, 0x9192022)
+	}
+	if len(m.Data) != 4 {
+		t.Errorf("Got microcode data length %d, expected %d", len(m.Data), 4)
+	}
+	if len(m.ExtendedSignatures) != 2 {
+		t.Errorf("Got extended signatures %d, expected %d", len(m.ExtendedSignatures), 2)
+	}
+	if m.ExtendedSignatures[0].ProcessorFlags != 0x80 {
+		t.Errorf("Got extended #0 microcode processor flags %#x, expected %#x",
+			m.ExtendedSignatures[0].ProcessorFlags, 0x80)
+	}
+	if m.ExtendedSignatures[0].Signature != 0x906a3 {
+		t.Errorf("Got extended #0 processor signature %#x, expected %#x",
+			m.ExtendedSignatures[0].Signature, 0x906a3)
+	}
+	if m.ExtendedSignatures[1].ProcessorFlags != 0x80 {
+		t.Errorf("Got extended #1 microcode processor flags %#x, expected %#x",
+			m.ExtendedSignatures[1].ProcessorFlags, 0x80)
+	}
+	if m.ExtendedSignatures[1].Signature != 0x906a4 {
+		t.Errorf("Got extended #1 processor signature %#x, expected %#x",
+			m.ExtendedSignatures[1].Signature, 0x906a4)
+	}
+}
+
+func TestParseMicrocode(t *testing.T) {
+	var m *Microcode
+	var err error
+
+	if m, err = ParseIntelMicrocode(bytes.NewBuffer(testMicrocode)); err != nil {
+		t.Errorf("Failed to parse microcode %v", err)
+		return
+	}
+	if m.HeaderProcessorFlags != 0x80 {
+		t.Errorf("Got microcode processor flags %#x, expected %#x", m.HeaderProcessorFlags, 0x80)
+	}
+	if m.HeaderDataSize != 4 {
+		t.Errorf("Got microcode data size %#x, expected %#x", m.HeaderDataSize, 4)
+	}
+	if m.HeaderTotalSize != 0x34 {
+		t.Errorf("Got microcode total size %#x, expected %#x", m.HeaderTotalSize, 0x34)
+	}
+	if m.HeaderProcessorSignature != 0x906a3 {
+		t.Errorf("Got microcode processor signature %#x, expected %#x", m.HeaderProcessorSignature, 0x906a3)
+	}
+	if m.HeaderDate != 0x9192022 {
+		t.Errorf("Got microcode date %#x, expected %#x", m.HeaderDate, 0x9192022)
+	}
+	if len(m.Data) != 4 {
+		t.Errorf("Got microcode data length %d, expected %d", len(m.Data), 4)
+	}
+	if len(m.ExtendedSignatures) != 0 {
+		t.Errorf("Got extended signatures %d, expected %d", len(m.ExtendedSignatures), 0)
+	}
+}
+
+func TestParseMicrocodeErrors(t *testing.T) {
+	// Invalid checksum
+	testData := make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[16] += 1
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// Header version invlaid
+	testData = make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[0] = 2
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// Datasize not multiple of 4
+	testData = make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[28] += 1
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// Datasize invalid
+	testData = make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[28] = 8
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// TotalSize invalid
+	testData = make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[32] = 0
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// TotalSize invalid
+	testData = make([]byte, len(testMicrocode))
+	copy(testData, testMicrocode)
+	testData[32] += 1
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// ExtTable invalid checksum
+	testData = make([]byte, len(testMicrocodeExtTable))
+	copy(testData, testMicrocodeExtTable)
+	testData[len(testData)-1] += 1
+
+	if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+		t.Errorf("Exptected error but didn't get one")
+	}
+
+	// Input to short
+	for i := 0; i < len(testMicrocodeExtTable)-1; i++ {
+		testData = make([]byte, i)
+		copy(testData, testMicrocodeExtTable[:i])
+
+		if _, err := ParseIntelMicrocode(bytes.NewBuffer(testData)); err == nil {
+			t.Errorf("Exptected error but didn't get one")
+		}
+	}
+}


### PR DESCRIPTION
Add Intel microcode parser and unit tests.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>