### PR TITLE
[intel/fit] Fix a typo in ParseKeyManifest

### DIFF
--- a/pkg/intel/metadata/fit/ent_key_manifest_record.go
+++ b/pkg/intel/metadata/fit/ent_key_manifest_record.go
@@ -70,7 +70,7 @@ func (entry *EntryKeyManifestRecord) ParseData() (*bgkey.Manifest, *cbntkey.Mani
 // ParseKeyManifest returns a key manifest if it was able to
 // parse one.
 func (table Table) ParseKeyManifest(firmware []byte) (*bgkey.Manifest, *cbntkey.Manifest, error) {
-	hdr := table.First(EntryTypeBootPolicyManifest)
+	hdr := table.First(EntryTypeKeyManifestRecord)
 	if hdr == nil {
 		return nil, nil, ErrNotFound{}
 	}


### PR DESCRIPTION
Fixing a typo in the code. Otherwise I get a panic:
```
panic: interface conversion: fit.Entry is *fit.EntryBootPolicyManifestRecord, not *fit.EntryKeyManifestRecord [recovered]
```