### PR TITLE
fix(intel/metadata/bg): Do not reuse Hash instance.

### DIFF
--- a/pkg/intel/metadata/bg/crypto_routines.go
+++ b/pkg/intel/metadata/bg/crypto_routines.go
@@ -31,11 +31,11 @@ const (
 )
 
 var hashInfo = []struct {
-	alg  Algorithm
-	hash hash.Hash
+	alg         Algorithm
+	hashFactory func() hash.Hash
 }{
-	{AlgSHA1, crypto.SHA1.New()},
-	{AlgSHA256, crypto.SHA256.New()},
+	{AlgSHA1, crypto.SHA1.New},
+	{AlgSHA256, crypto.SHA256.New},
 }
 
 // IsNull returns true if a is AlgNull or zero (unset).
@@ -48,10 +48,10 @@ func (a Algorithm) IsNull() bool {
 func (a Algorithm) Hash() (hash.Hash, error) {
 	for _, info := range hashInfo {
 		if info.alg == a {
-			if info.hash == nil {
+			if info.hashFactory == nil {
 				return nil, fmt.Errorf("go hash algorithm #%snot available", info.alg.String())
 			}
-			return info.hash, nil
+			return info.hashFactory(), nil
 		}
 	}
 	return nil, fmt.Errorf("hash algorithm not supported: %s", a.String())


### PR DESCRIPTION
PR #394 reintroduced a bug for the BtG 1.0 code, that has been fixed by commit [743961f](https://github.com/linuxboot/fiano/commit/743961f033d5d7d2d1305f9b7325d1204bd8f24c) for the CBnT code already, and that results in the wrong calculation of the Key Manifest Pubkey Hash in PrintKMPubKey(). This change reapplies the same fix for the BtG 1.0 code.
