### PR TITLE
pkg/compression: Implement system brotli compression

### DIFF
--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -15,6 +15,7 @@ import (
 	"github.com/linuxboot/fiano/pkg/guid"
 )
 
+var brotliPath = flag.String("brotliPath", "brotli", "Path to system brotli command used for brotli encoding.")
 var xzPath = flag.String("xzPath", "xz", "Path to system xz command used for lzma encoding. If unset, an internal lzma implementation is used.")
 
 // Compressor defines a single compression scheme (such as LZMA).
@@ -29,6 +30,7 @@ type Compressor interface {
 
 // Well-known GUIDs for GUIDed sections containing compressed data.
 var (
+	BROTLIGUID  = *guid.MustParse("3D532050-5CDA-4FD0-879E-0F7F630D5AFB")
 	LZMAGUID    = *guid.MustParse("EE4E5898-3914-4259-9D6E-DC7BD79403CF")
 	LZMAX86GUID = *guid.MustParse("D42AE6BD-1352-4BFB-909A-CA72A6EAE889")
 	ZLIBGUID    = *guid.MustParse("CE3233F5-2CD6-4D87-9152-4A238BB6D1C4")
@@ -45,6 +47,8 @@ func CompressorFromGUID(guid *guid.GUID) Compressor {
 		lzma = &LZMA{}
 	}
 	switch *guid {
+	case BROTLIGUID:
+		return &SystemBROTLI{*brotliPath};
 	case LZMAGUID:
 		return lzma
 	case LZMAX86GUID:

--- a/pkg/compression/compression.go
+++ b/pkg/compression/compression.go
@@ -48,7 +48,7 @@ func CompressorFromGUID(guid *guid.GUID) Compressor {
 	}
 	switch *guid {
 	case BROTLIGUID:
-		return &SystemBROTLI{*brotliPath};
+		return &SystemBROTLI{*brotliPath}
 	case LZMAGUID:
 		return lzma
 	case LZMAX86GUID:

--- a/pkg/compression/systembrotli.go
+++ b/pkg/compression/systembrotli.go
@@ -53,7 +53,7 @@ func (c *SystemBROTLI) Encode(decodedData []byte) ([]byte, error) {
 	}
 
 	// This seems to be the buffer size needed by the UEFI decompressor
-	header := []byte{0x00, 0x00, 0x00, 0x02,0,0,0,0}
+	header := []byte{0x00, 0x00, 0x00, 0x02, 0, 0, 0, 0}
 
 	header = append(buf.Bytes(), header...)
 

--- a/pkg/compression/systembrotli.go
+++ b/pkg/compression/systembrotli.go
@@ -1,0 +1,63 @@
+// Copyright 2023 the LinuxBoot Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package compression
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os/exec"
+)
+
+// SystemBROTLI implements Compression and calls out to the system's compressor
+type SystemBROTLI struct {
+	brotliPath string
+}
+
+// Name returns the type of compression employed.
+func (c *SystemBROTLI) Name() string {
+	return "BROTLI"
+}
+
+// Decode decodes a byte slice of BROTLI data.
+func (c *SystemBROTLI) Decode(encodedData []byte) ([]byte, error) {
+	// The start of the brotli section contains an 8 byte header describing
+	// the final uncompressed size. The real data starts at 0x10
+
+	cmd := exec.Command(c.brotliPath, "--stdout", "-d")
+	cmd.Stdin = bytes.NewBuffer(encodedData[0x10:])
+
+	decodedData, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedData, nil
+}
+
+// Encode encodes a byte slice with BROTLI.
+func (c *SystemBROTLI) Encode(decodedData []byte) ([]byte, error) {
+	cmd := exec.Command(c.brotliPath, "--stdout")
+	cmd.Stdin = bytes.NewBuffer(decodedData)
+
+	encodedData, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate the size of the decoded data for the header
+	buf := &bytes.Buffer{}
+	if err := binary.Write(buf, binary.LittleEndian, uint64(len(decodedData))); err != nil {
+		return nil, err
+	}
+
+	// This seems to be the buffer size needed by the UEFI decompressor
+	header := []byte{0x00, 0x00, 0x00, 0x02,0,0,0,0}
+
+	header = append(buf.Bytes(), header...)
+
+	encodedData = append(header, encodedData...)
+
+	return encodedData, nil
+}

--- a/pkg/uefi/section.go
+++ b/pkg/uefi/section.go
@@ -282,6 +282,8 @@ func CreateSection(t SectionType, buf []byte, encap []Firmware, g *guid.GUID) (*
 		guidDefHeader := &SectionGUIDDefined{}
 		guidDefHeader.GUID = *g
 		switch *g {
+		case compression.BROTLIGUID:
+			guidDefHeader.Compression = "BROTLI"
 		case compression.LZMAGUID:
 			guidDefHeader.Compression = "LZMA"
 		case compression.LZMAX86GUID:


### PR DESCRIPTION
This has been tested to decompress and recompress brotli compressed images. So far a brotli compressed OVMF image fails to boot after recompression. It fails at reading the section headers.