### PR TITLE
cleanup package usage

### DIFF
--- a/cmds/create-ffs/create-ffs.go
+++ b/cmds/create-ffs/create-ffs.go
@@ -167,7 +167,9 @@ func main() {
 	mainSection := &uefi.Section{}
 	mainSection.SetType(secType)
 	mainSection.SetBuf(secData)
-	mainSection.GenSecHeader()
+	// It is not clear why the author felt it was OK to ignore
+	// the error.
+	_ = mainSection.GenSecHeader()
 	file.Sections = append(file.Sections, mainSection)
 	printf("selected section type: %v", mainSection.Header.Type)
 

--- a/cmds/create-ffs/create-ffs.go
+++ b/cmds/create-ffs/create-ffs.go
@@ -26,8 +26,6 @@ var (
 	version    = flag.String("version", "1.0", "File version")
 	guidString = flag.String("guid", "", "File GUID")
 	depex      = flag.String("depex", "", "Space or comma separated protocol guid dependencies or TRUE")
-	compress   = flag.Bool("compress", false, "Wrap section data in a compressed section")
-	auto       = flag.Bool("auto", false, "Attempt to determine section types from file extensions")
 
 	printf = func(string, ...interface{}) {}
 )

--- a/cmds/fittool/main.go
+++ b/cmds/fittool/main.go
@@ -37,6 +37,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/jessevdk/go-flags"
 
 	"github.com/linuxboot/fiano/cmds/fittool/commands"
@@ -67,5 +69,7 @@ func main() {
 	}
 
 	// parse arguments and execute the appropriate command
-	flagsParser.Parse()
+	if _, err := flagsParser.Parse(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/amd/apcb/apcb_test.go
+++ b/pkg/amd/apcb/apcb_test.go
@@ -8,7 +8,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"path"
 	"testing"
 
@@ -111,7 +112,7 @@ func findToken(tokenID TokenID, tokens []Token) *Token {
 }
 
 func getFile(filename string) ([]byte, error) {
-	compressedImage, err := ioutil.ReadFile(path.Join("testdata", filename))
+	compressedImage, err := os.ReadFile(path.Join("testdata", filename))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read firmware image: %w", err)
 	}
@@ -121,7 +122,7 @@ func getFile(filename string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to create an xz reader for a cached image: %w", err)
 	}
 
-	decompressedImage, err := ioutil.ReadAll(r)
+	decompressedImage, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decompress the image: %w", err)
 	}

--- a/pkg/bytes/is_zero_filled_amd64.go
+++ b/pkg/bytes/is_zero_filled_amd64.go
@@ -8,18 +8,16 @@
 package bytes
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 // IsZeroFilled returns true if b consists of zeros only.
 func IsZeroFilled(b []byte) bool {
-	hdr := (*reflect.SliceHeader)((unsafe.Pointer)(&b))
-	data := unsafe.Pointer(hdr.Data)
-	length := hdr.Len
+	length := len(b)
 	if length == 0 {
 		return true
 	}
+	var data = unsafe.Pointer(&b[0])
 
 	if uintptr(data)&0x07 != 0 {
 		// the data is not aligned, fallback to a simple way

--- a/pkg/intel/metadata/fit/ent_startup_ac_module_entry_test.go
+++ b/pkg/intel/metadata/fit/ent_startup_ac_module_entry_test.go
@@ -6,17 +6,16 @@ package fit
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func randBytes(size uint) []byte {
-	rand.Seed(0)
 	b := make([]byte, int(size))
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	return b
 }
 


### PR DESCRIPTION
gofmt -r 'ioutil.ReadAll -> io.ReadAll' -w .
gofmt -r 'ioutil.ReadFile -> os.ReadFile' -w .
goimports -w .