### PR TITLE
pkg/uefi/meregion: add TestFindFPTSignature test case

### DIFF
--- a/pkg/uefi/meregion_test.go
+++ b/pkg/uefi/meregion_test.go
@@ -59,3 +59,35 @@ func TestMEName_UnmarshalText(t *testing.T) {
 		})
 	}
 }
+
+func TestFindFPTSignature(t *testing.T) {
+	var empty16 = make([]byte, 16)
+	var empty12 = make([]byte, 12)
+	var empty = make([]byte, 128)
+
+	var firstRow = append(MEFPTSignature, empty12...)
+	var secondRow = append(empty16, firstRow...)
+	var elsewhere = append(empty, firstRow...)
+
+	var tests = []struct {
+		name string
+		blob []byte
+		res  int
+	}{
+		{"beginning", firstRow, 4},
+		{"2nd row", secondRow, 20},
+		{"elsewhere", elsewhere, 132},
+		{"nowhere", empty, -1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r, e := FindMEDescriptor(test.blob)
+			if r != test.res {
+				t.Errorf("got position %d want %d", r, test.res)
+			}
+			if test.res == -1 && e == nil {
+				t.Errorf("expected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
I have no idea what Go is trying to tell me:

```
--- FAIL: TestFindFPTSignature (0.00s)
    --- FAIL: TestFindFPTSignature/beginning (0.00s)
panic: runtime error: slice bounds out of range [:20] with capacity 16 [recovered]
        panic: runtime error: slice bounds out of range [:20] with capacity 16

goroutine 4010 [running]:
testing.tRunner.func1.2({0x5af120, 0xc00001cc90})
        /home/dama/bin/go1.21.0/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
        /home/dama/bin/go1.21.0/src/testing/testing.go:1548 +0x397
panic({0x5af120?, 0xc00001cc90?})
        /home/dama/bin/go1.21.0/src/runtime/panic.go:914 +0x21f
github.com/linuxboot/fiano/pkg/uefi.FindMEDescriptor({0xc000f09e00, 0x5ac?, 0x10})
        /home/dama/Projects/Fiedka/fiano/pkg/uefi/meregion.go:106 +0x125
github.com/linuxboot/fiano/pkg/uefi.TestFindFPTSignature.func1(0xc000bd3860)
        /home/dama/Projects/Fiedka/fiano/pkg/uefi/meregion_test.go:84 +0x34
testing.tRunner(0xc000bd3860, 0xc00002b160)
        /home/dama/bin/go1.21.0/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 4009
        /home/dama/bin/go1.21.0/src/testing/testing.go:1648 +0x3ad
FAIL    github.com/linuxboot/fiano/pkg/uefi     0.284s
FAIL
```